### PR TITLE
Return DriverOutcome instead of Result for correct exit codes

### DIFF
--- a/examples/demo_errors.rs
+++ b/examples/demo_errors.rs
@@ -92,7 +92,7 @@ fn main() {
         println!("Args: {:?}", args_vec);
         println!("{}", "=".repeat(80));
 
-        let result = args::from_slice::<GitArgs>(args_vec);
+        let result = args::from_slice::<GitArgs>(args_vec).into_result();
         match result {
             Ok(_) => println!("✓ Successfully parsed arguments"),
             Err(e) => {

--- a/examples/global_args.rs
+++ b/examples/global_args.rs
@@ -52,9 +52,6 @@ enum Subcommand {
 }
 
 fn main() {
-    let result: Args = match figue::from_std_args() {
-        Ok(r) => r,
-        Err(e) => panic!("{e}"),
-    };
+    let result: Args = figue::from_std_args().unwrap();
     println!("{}", result.pretty());
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -129,7 +129,7 @@ impl<T> ConfigBuilder<T> {
     /// After calling this, create a `Driver` and call `run()`:
     /// ```ignore
     /// let config = builder::<MyArgs>()?.cli(...).env(...).build();
-    /// let output = Driver::new(config).run().expect_value();
+    /// let output = Driver::new(config).run().unwrap();
     /// ```
     pub fn build(self) -> Config<T> {
         Config {

--- a/tests/integration/ariadne.rs
+++ b/tests/integration/ariadne.rs
@@ -41,8 +41,7 @@ fn test_ariadne_unknown_flag_with_suggestion() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let result: Result<Args, _> = figue::from_slice(&["--c0ncurrency", "4"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--c0ncurrency", "4"]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_unknown_flag_with_suggestion", ariadne_output);
@@ -55,8 +54,7 @@ fn test_ariadne_missing_argument() {
         #[facet(args::named)]
         required_field: String,
     }
-    let result: Result<Args, _> = figue::from_slice(&[]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&[]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_missing_argument", ariadne_output);
@@ -69,8 +67,7 @@ fn test_ariadne_invalid_value() {
         #[facet(args::named)]
         count: usize,
     }
-    let result: Result<Args, _> = figue::from_slice(&["--count", "not-a-number"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--count", "not-a-number"]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_invalid_value", ariadne_output);
@@ -93,8 +90,7 @@ fn test_ariadne_unknown_subcommand() {
         command: Command,
     }
 
-    let result: Result<Args, _> = figue::from_slice(&["buidl"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["buidl"]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_unknown_subcommand", ariadne_output);
@@ -107,8 +103,7 @@ fn test_ariadne_unexpected_positional() {
         #[facet(args::named)]
         name: String,
     }
-    let result: Result<Args, _> = figue::from_slice(&["unexpected", "--name", "value"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["unexpected", "--name", "value"]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_unexpected_positional", ariadne_output);
@@ -121,8 +116,7 @@ fn test_ariadne_expected_value_got_eof() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let result: Result<Args, _> = figue::from_slice(&["--concurrency"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--concurrency"]).unwrap_err();
 
     let ariadne_output = strip_ansi(&err.to_string());
     insta::assert_snapshot!("ariadne_expected_value_got_eof", ariadne_output);

--- a/tests/integration/err.rs
+++ b/tests/integration/err.rs
@@ -11,8 +11,7 @@ fn test_error_non_struct_type_not_supported() {
         Something,
         Else,
     }
-    let args: Result<Args, _> = figue::from_slice(&["error", "wrong", "type"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["error", "wrong", "type"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -23,8 +22,7 @@ fn test_error_missing_value_for_argument() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--concurrency"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--concurrency"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -35,8 +33,7 @@ fn test_error_wrong_type_for_argument() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--concurrency", "yes"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--concurrency", "yes"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -49,8 +46,7 @@ fn test_error_missing_value_for_argument_short_missed() {
         #[facet(args::named, args::short = 'v')]
         verbose: bool,
     }
-    let args: Result<Args, _> = figue::from_slice(&["-j", "-v"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["-j", "-v"]).unwrap_err();
     eprintln!("{err}");
     assert_diag_snapshot!(err);
 }
@@ -62,8 +58,7 @@ fn test_error_missing_value_for_argument_short_eof() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let args: Result<Args, _> = figue::from_slice(&["-j"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["-j"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -74,8 +69,7 @@ fn test_error_unknown_argument() {
         #[facet(args::named, args::short = 'j')]
         concurrency: usize,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--c0ncurrency"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--c0ncurrency"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -86,8 +80,7 @@ fn test_error_number_outside_range() {
         #[facet(args::named)]
         small: u8,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--small", "1000"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--small", "1000"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -98,8 +91,7 @@ fn test_error_negative_value_for_unsigned() {
         #[facet(args::named)]
         count: usize,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--count", "-10"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--count", "-10"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -110,8 +102,7 @@ fn test_error_out_of_range() {
         #[facet(args::named)]
         byte: u8,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--byte", "1000"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--byte", "1000"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -122,8 +113,7 @@ fn test_error_bool_with_invalid_value_positional() {
         #[facet(args::named)]
         enable: bool,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--enable", "maybe"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--enable", "maybe"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -134,8 +124,7 @@ fn test_error_char_with_multiple_chars() {
         #[facet(args::named)]
         letter: char,
     }
-    let args: Result<Args, _> = figue::from_slice(&["--letter", "abc"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--letter", "abc"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -147,8 +136,7 @@ fn test_error_option_with_multiple_values() {
         maybe: Option<String>,
     }
     // Try to provide a list where an Option is expected
-    let args: Result<Args, _> = figue::from_slice(&["--maybe", "value1", "value2"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--maybe", "value1", "value2"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -160,8 +148,7 @@ fn test_error_unexpected_positional_arg() {
         name: String,
     }
     // Provide a positional arg when none is expected
-    let args: Result<Args, _> = figue::from_slice(&["unexpected", "--name", "value"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["unexpected", "--name", "value"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -175,7 +162,6 @@ fn test_error_invalid_ip_address() {
         address: IpAddr,
     }
     // Provide an invalid IP address
-    let args: Result<Args, _> = figue::from_slice(&["--address", "not-an-ip"]);
-    let err = args.unwrap_err();
+    let err = figue::from_slice::<Args>(&["--address", "not-an-ip"]).unwrap_err();
     assert_diag_snapshot!(err);
 }

--- a/tests/integration/layered.rs
+++ b/tests/integration/layered.rs
@@ -88,37 +88,31 @@ fn test_layered_all_sources() {
         .build();
 
     let driver = Driver::new(config);
-    let result = driver.run();
+    let args = driver.run().unwrap();
 
-    match result {
-        Ok(output) => {
-            let args = output.value;
-            // CLI: --verbose
-            assert!(args.verbose, "verbose should be true from CLI");
-            // File: host = "0.0.0.0"
-            assert_eq!(args.config.host, "0.0.0.0", "host should come from file");
-            // Env overrides file: port
-            assert_eq!(args.config.port, 4000, "port should be overridden by env");
-            // File: database.url
-            assert_eq!(
-                args.config.database.url, "postgres://localhost/mydb",
-                "database.url should come from file"
-            );
-            // File: database.max_connections
-            assert_eq!(
-                args.config.database.max_connections, 20,
-                "max_connections should come from file"
-            );
-            // Env overrides default: database.timeout_secs
-            assert_eq!(
-                args.config.database.timeout_secs, 60,
-                "timeout_secs should be overridden by env"
-            );
-            // Default: tls is None
-            assert!(args.config.tls.is_none(), "tls should be None (default)");
-        }
-        Err(e) => panic!("expected success, got error: {}", e),
-    }
+    // CLI: --verbose
+    assert!(args.verbose, "verbose should be true from CLI");
+    // File: host = "0.0.0.0"
+    assert_eq!(args.config.host, "0.0.0.0", "host should come from file");
+    // Env overrides file: port
+    assert_eq!(args.config.port, 4000, "port should be overridden by env");
+    // File: database.url
+    assert_eq!(
+        args.config.database.url, "postgres://localhost/mydb",
+        "database.url should come from file"
+    );
+    // File: database.max_connections
+    assert_eq!(
+        args.config.database.max_connections, 20,
+        "max_connections should come from file"
+    );
+    // Env overrides default: database.timeout_secs
+    assert_eq!(
+        args.config.database.timeout_secs, 60,
+        "timeout_secs should be overridden by env"
+    );
+    // Default: tls is None
+    assert!(args.config.tls.is_none(), "tls should be None (default)");
 }
 
 #[test]
@@ -175,33 +169,27 @@ fn test_layered_cli_overrides_all() {
         .build();
 
     let driver = Driver::new(config);
-    let result = driver.run();
+    let args = driver.run().unwrap();
 
-    match result {
-        Ok(output) => {
-            let args = output.value;
-            // CLI wins for host
-            assert_eq!(args.config.host, "cli-host", "host should come from CLI");
-            // CLI wins for port
-            assert_eq!(args.config.port, 3333, "port should come from CLI");
-            // Env wins for database.url (no CLI override)
-            assert_eq!(
-                args.config.database.url, "postgres://env/db",
-                "database.url should come from env"
-            );
-            // File wins for max_connections (no env or CLI override)
-            assert_eq!(
-                args.config.database.max_connections, 100,
-                "max_connections should come from file"
-            );
-            // File wins for timeout_secs (no env or CLI override for this one)
-            assert_eq!(
-                args.config.database.timeout_secs, 999,
-                "timeout_secs should come from file"
-            );
-        }
-        Err(e) => panic!("expected success, got error: {}", e),
-    }
+    // CLI wins for host
+    assert_eq!(args.config.host, "cli-host", "host should come from CLI");
+    // CLI wins for port
+    assert_eq!(args.config.port, 3333, "port should come from CLI");
+    // Env wins for database.url (no CLI override)
+    assert_eq!(
+        args.config.database.url, "postgres://env/db",
+        "database.url should come from env"
+    );
+    // File wins for max_connections (no env or CLI override)
+    assert_eq!(
+        args.config.database.max_connections, 100,
+        "max_connections should come from file"
+    );
+    // File wins for timeout_secs (no env or CLI override for this one)
+    assert_eq!(
+        args.config.database.timeout_secs, 999,
+        "timeout_secs should come from file"
+    );
 }
 
 /// Simpler structure for testing dump output with all sources visible.

--- a/tests/integration/short_chaining.rs
+++ b/tests/integration/short_chaining.rs
@@ -113,8 +113,7 @@ fn test_error_unknown_in_chain() {
     }
 
     // Test `-axc` where 'x' doesn't exist
-    let result: Result<Args, _> = figue::from_slice(&["-axc"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["-axc"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 

--- a/tests/integration/subcommand.rs
+++ b/tests/integration/subcommand.rs
@@ -317,8 +317,7 @@ fn test_unknown_subcommand_error() {
         command: Command,
     }
 
-    let result: Result<Args, _> = figue::from_slice(&["unknown"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["unknown"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -340,8 +339,7 @@ fn test_missing_subcommand_shows_help() {
         command: Command,
     }
 
-    let result: Result<Args, _> = figue::from_slice(&[]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&[]).unwrap_err();
     // Should return Help, not Failed
     assert!(
         matches!(err, DriverError::Help { .. }),
@@ -381,8 +379,7 @@ fn test_missing_nested_subcommand_error() {
     }
 
     // Test missing nested subcommand - should show helpful error
-    let result: Result<Args, _> = figue::from_slice(&["ci"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["ci"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -417,8 +414,7 @@ fn test_wrong_argument_style_for_nested_subcommand() {
     }
 
     // Test wrong argument style - should suggest correct subcommand usage
-    let result: Result<Args, _> = figue::from_slice(&["ci", "--action", "gen"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["ci", "--action", "gen"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 
@@ -453,8 +449,7 @@ fn test_unknown_nested_subcommand_error() {
     }
 
     // Test unknown nested subcommand
-    let result: Result<Args, _> = figue::from_slice(&["ci", "unknown"]);
-    let err = result.unwrap_err();
+    let err = figue::from_slice::<Args>(&["ci", "unknown"]).unwrap_err();
     assert_diag_snapshot!(err);
 }
 


### PR DESCRIPTION
## Summary

- Changes `from_slice`, `from_std_args`, and `Driver::run()` to return `DriverOutcome<T>` instead of `Result<T, DriverError>`
- `DriverOutcome` is opaque (no `Try` impl) so users can't accidentally use `?` and get wrong exit codes
- Users call `.unwrap()` which handles exits correctly (prints output, exits with proper code)
- Also implements `Termination` for `DriverError`

## API Changes

Before:
```rust
fn main() -> Result<(), Box<dyn Error>> {
    let args = figue::from_std_args::<Args>()?;  // BUG: --help exits with code 1
    Ok(())
}
```

After:
```rust
fn main() {
    let args = figue::from_std_args::<Args>().unwrap();  // --help exits with code 0
}
```

For testing error cases:
```rust
let err = figue::from_slice::<Args>(&["--bad"]).unwrap_err();
```

For manual handling:
```rust
let result = figue::from_slice::<Args>(&[...]).into_result();
match result { ... }
```

## Test plan

- [x] All 382 tests pass
- [x] Examples compile and work

Fixes #15 (exit code part)

Note: Version defaulting to "unknown" is tracked separately in #18