### PR TITLE
Remove dead code and module-level allow(dead_code) attributes

### DIFF
--- a/src/config_format.rs
+++ b/src/config_format.rs
@@ -1,7 +1,6 @@
 //! Config file format abstraction for layered configuration.
 //!
 //! This module is under active development and not yet wired into the main API.
-#![allow(dead_code)]
 //!
 //! This module provides the [`ConfigFormat`] trait for pluggable config file parsing,
 //! along with a built-in [`JsonFormat`] implementation.

--- a/src/config_value_parser.rs
+++ b/src/config_value_parser.rs
@@ -1,5 +1,4 @@
 //! Parser that converts `ConfigValue` trees into `ParseEvent` streams for deserialization.
-#![allow(dead_code)]
 //!
 //! This allows us to deserialize `ConfigValue` into arbitrary Facet types using the
 //! standard `facet-format` deserializer infrastructure.
@@ -683,11 +682,6 @@ impl<'input> ConfigValueParser<'input> {
         }
     }
 
-    /// Get the most recent span.
-    pub fn last_span(&self) -> Option<Span> {
-        self.last_span
-    }
-
     /// Update the last span from a `Sourced` wrapper.
     fn update_span<T>(&mut self, sourced: &Sourced<T>) {
         if let Some(span) = sourced.span {
@@ -1045,22 +1039,8 @@ impl<'input> ConfigValueParser<'input> {
     }
 }
 
-/// Errors that can occur while parsing a `ConfigValue`.
-#[derive(Debug)]
-pub enum ConfigValueParseError {
-    /// Generic error message.
-    Message(String),
-}
-
-impl core::fmt::Display for ConfigValueParseError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ConfigValueParseError::Message(msg) => write!(f, "{}", msg),
-        }
-    }
-}
-
-impl core::error::Error for ConfigValueParseError {}
+/// Error type for ConfigValue parsing (infallible - parsing always succeeds).
+pub type ConfigValueParseError = std::convert::Infallible;
 
 /// Serializer that builds a ConfigValue tree.
 pub struct ConfigValueSerializer {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -16,7 +16,6 @@
 //! - [ ] Add facet-validate pass after deserialization
 //! - [ ] Improve render_pretty() with Ariadne integration
 //! - [ ] Migrate build_traced tests to driver API
-#![allow(dead_code)]
 #![allow(clippy::result_large_err)]
 
 use std::marker::PhantomData;

--- a/src/layers/env.rs
+++ b/src/layers/env.rs
@@ -1,7 +1,5 @@
 //! Schema-driven environment variable parser that outputs ConfigValue with provenance.
 //!
-//! This module is under active development and not yet wired into the main API.
-#![allow(dead_code)]
 //!
 //! This parser:
 //! - Uses the pre-built Schema to know the config field structure

--- a/src/layers/file.rs
+++ b/src/layers/file.rs
@@ -1,7 +1,6 @@
 //! Schema-driven config file parser that outputs ConfigValue with provenance.
 //!
 //! This module is under active development and not yet wired into the main API.
-#![allow(dead_code)]
 //!
 //! This parser:
 //! - Uses the pre-built Schema to validate config structure
@@ -57,10 +56,6 @@ struct ValidPaths {
 impl ValidPaths {
     fn new() -> Self {
         Self::default()
-    }
-
-    fn add_container(&mut self, path: Vec<String>) {
-        self.paths.insert(path);
     }
 
     fn add_leaf(&mut self, path: Vec<String>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
 // Allow deprecated during transition to new driver-based API
-#![allow(deprecated)]
 #![doc = include_str!("../README.md")]
 
 extern crate self as figue;

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,7 +1,6 @@
 //! Deep-merge functionality for layered configuration.
 //!
 //! This module is under active development and not yet wired into the main API.
-#![allow(dead_code)]
 //!
 //! This module provides the ability to merge multiple [`ConfigValue`] trees
 //! together, with later values taking precedence over earlier ones.

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,85 +1,10 @@
 //! Standard path representation for navigating schemas and ConfigValue trees.
 //!
-//! This module is under active development and not yet wired into the main API.
-#![allow(dead_code)]
-//!
-//! This is intentionally small and stable: a `Path` is a thin wrapper over
-//! `Vec<String>`, where each segment is a name. Indices are stringified numbers.
-//!
-//! Use this for diagnostics and for navigation helpers in `schema` and `config_value`.
+//! A `Path` is a thin wrapper over `Vec<String>`, where each segment is a name.
+//! Indices are stringified numbers.
 
-use std::fmt;
 use std::string::String;
 use std::vec::Vec;
 
 /// A path into a schema or ConfigValue tree.
 pub type Path = Vec<String>;
-
-/// Convenience helpers for Path.
-pub trait PathExt {
-    /// Create an empty root path.
-    fn root() -> Self;
-
-    /// Push a raw segment.
-    fn push_segment(&mut self, segment: impl Into<String>);
-
-    /// Push a field segment.
-    fn push_field(&mut self, name: impl Into<String>);
-
-    /// Push a variant segment.
-    fn push_variant(&mut self, name: impl Into<String>);
-
-    /// Push an index segment (stringified number).
-    fn push_index(&mut self, index: usize);
-
-    /// Push a key segment.
-    fn push_key(&mut self, key: impl Into<String>);
-}
-
-impl PathExt for Path {
-    fn root() -> Self {
-        Vec::new()
-    }
-
-    fn push_segment(&mut self, segment: impl Into<String>) {
-        self.push(segment.into());
-    }
-
-    fn push_field(&mut self, name: impl Into<String>) {
-        self.push_segment(name);
-    }
-
-    fn push_variant(&mut self, name: impl Into<String>) {
-        self.push_segment(name);
-    }
-
-    fn push_index(&mut self, index: usize) {
-        self.push_segment(index.to_string());
-    }
-
-    fn push_key(&mut self, key: impl Into<String>) {
-        self.push_segment(key);
-    }
-}
-
-/// Display wrapper for a Path without relying on orphan impls.
-pub struct PathDisplay<'a>(pub &'a Path);
-
-impl fmt::Display for PathDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut first = true;
-        for seg in self.0 {
-            if !first {
-                write!(f, ".")?;
-            }
-            write!(f, "{seg}")?;
-            first = false;
-        }
-        Ok(())
-    }
-}
-
-/// Convenience helper for formatting paths.
-pub fn display_path(path: &Path) -> PathDisplay<'_> {
-    PathDisplay(path)
-}

--- a/src/reflection.rs
+++ b/src/reflection.rs
@@ -1,27 +1,5 @@
 use crate::config_value::{ConfigValue, Sourced};
 
-/// Check if a field is marked with `args::counted`.
-#[deprecated(note = "move to schema/from_schema.rs")]
-pub(crate) fn is_counted_field(field: &facet_core::Field) -> bool {
-    field.has_attr(Some("args"), "counted")
-}
-
-/// Check if a shape is a supported type for counted fields (integer types).
-#[deprecated(note = "move to schema/from_schema.rs")]
-pub(crate) const fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
-    use facet_core::{NumericType, PrimitiveType, Type};
-    matches!(
-        shape.ty,
-        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { .. }))
-    )
-}
-
-/// Check if a field is marked with `args::config`.
-#[deprecated(note = "move to schema/from_schema.rs")]
-pub(crate) fn is_config_field(field: &facet_core::Field) -> bool {
-    field.has_attr(Some("args"), "config")
-}
-
 /// Coerce ConfigValue types based on the target shape.
 /// This is needed because environment variables always come in as strings,
 /// but we want to display them with their proper types (int, bool, etc).

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,6 @@
 //! Schema representation for CLI arguments and config.
 //!
 //! This module is under active development and not yet fully wired into the main API.
-#![allow(dead_code)]
 
 use std::hash::RandomState;
 

--- a/src/schema/from_schema.rs
+++ b/src/schema/from_schema.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, hash::RandomState};
 
 use crate::{
     Attr,
-    reflection::{is_config_field, is_counted_field, is_supported_counted_type},
     schema::{
         ArgKind, ArgLevelSchema, ArgSchema, ConfigEnumSchema, ConfigEnumVariantSchema,
         ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, ConfigVecSchema, Docs, LeafKind,
@@ -771,4 +770,23 @@ fn arg_level_from_fields_with_prefix(
         },
         special,
     ))
+}
+
+/// Check if a field is marked with `args::counted`.
+fn is_counted_field(field: &facet_core::Field) -> bool {
+    field.has_attr(Some("args"), "counted")
+}
+
+/// Check if a shape is a supported type for counted fields (integer types).
+const fn is_supported_counted_type(shape: &'static facet_core::Shape) -> bool {
+    use facet_core::{NumericType, PrimitiveType, Type};
+    matches!(
+        shape.ty,
+        Type::Primitive(PrimitiveType::Numeric(NumericType::Integer { .. }))
+    )
+}
+
+/// Check if a field is marked with `args::config`.
+fn is_config_field(field: &facet_core::Field) -> bool {
+    field.has_attr(Some("args"), "config")
 }

--- a/tests/integration/help.rs
+++ b/tests/integration/help.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 
 use crate::assert_help_snapshot;
 use facet::Facet;

--- a/tests/integration/subcommand.rs
+++ b/tests/integration/subcommand.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 
 use crate::assert_diag_snapshot;
 use facet::Facet;


### PR DESCRIPTION
Closes #13

## Summary
- Remove module-level `#![allow(dead_code)]` from 15 files
- Remove module-level `#![allow(deprecated)]` from 3 files
- Remove deprecated provenance tracking infrastructure (ProvenanceTracker, etc.)
- Remove various unused code across multiple modules

## Changes by file

**provenance.rs**
- Removed `ProvenanceTracker` struct and all methods
- Removed `collect_provenance` and `collect_provenance_inner` functions
- Removed `provenance` field from `ConfigResult`
- Changed `ConfigResult::new()` to require explicit `(value, overrides, file_resolution)` args
- Removed deprecated constructors (`with_provenance`, `with_full_tracking`, `get_provenance`)

**path.rs**
- Removed unused `PathExt` trait
- Removed unused `PathDisplay` struct and `display_path` function

**config_value_parser.rs**
- Removed unused `last_span()` method
- Changed `ConfigValueParseError` from enum to type alias for `Infallible`

**layers/cli.rs**
- Removed unused `strict` field from `ParseContext`
- Removed unused `insert_at_path` method

**layers/file.rs**
- Removed unused `add_container` method

**builder.rs**
- Removed tests that used deleted provenance APIs

**config_value.rs**
- Removed unused `parse_cli_value` and `insert_nested_value` functions

**reflection.rs**
- Moved `is_counted_field`, `is_supported_counted_type`, `is_config_field` to `schema/from_schema.rs`

## Remaining allows
- `diagnostics.rs`: `#![allow(dead_code)]` kept for future provenance error improvements (see #14)

## Related
- Filed #27 for `schema` fields in env.rs and file.rs that are stored but not yet used for type-aware parsing

## Test plan
- [x] All 384 tests pass
- [x] No new clippy warnings