### PR TITLE
Refactor fill_defaults to use Schema instead of Shape

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -25,7 +25,7 @@ use std::vec::Vec;
 use crate::builder::Config;
 use crate::completions::{Shell, generate_completions_for_shape};
 use crate::config_value::ConfigValue;
-use crate::config_value_parser::{fill_defaults_from_shape, from_config_value};
+use crate::config_value_parser::{fill_defaults_from_schema, from_config_value};
 use crate::dump::dump_config_with_schema;
 use crate::help::generate_help_for_subcommand;
 use crate::layers::{cli::parse_cli, env::parse_env, file::parse_file};
@@ -263,8 +263,8 @@ impl<T: Facet<'static>> Driver<T> {
 
         // Phase 3: Fill defaults and check for missing required fields
         // This must happen BEFORE deserialization so we can show all missing fields at once
-        let value_with_defaults = fill_defaults_from_shape(&merged.value, T::SHAPE);
-        tracing::debug!(value_with_defaults = ?value_with_defaults, "driver: after fill_defaults_from_shape");
+        let value_with_defaults = fill_defaults_from_schema(&merged.value, &self.config.schema);
+        tracing::debug!(value_with_defaults = ?value_with_defaults, "driver: after fill_defaults_from_schema");
 
         // Check for missing required fields by walking the schema
         let mut missing_fields = Vec::new();


### PR DESCRIPTION
## Summary

This PR introduces a new `fill_defaults_from_schema` function that leverages the pre-computed Schema structure for filling default values, replacing the usage of `fill_defaults_from_shape`. The Schema already has flattened field information resolved, eliminating the need to manually walk through Shape's flatten attributes.

## Changes

- Added `fill_defaults_from_schema` as the new entry point for default filling
- Added helper functions for handling different schema levels:
  - `fill_defaults_from_arg_level` for args-level fields (already flattened in schema)
  - `fill_defaults_from_config_struct` for config section fields
  - `fill_defaults_from_subcommand` for subcommand variant fields
  - `fill_defaults_from_value_schema` for recursive handling of nested values
  - `get_default_from_value_schema` for extracting defaults from value schemas
- Updated `driver.rs` to use the new schema-based approach
- The old `fill_defaults_from_shape` function is preserved for backward compatibility

## Test plan

- [ ] Verify existing tests pass with the new implementation
- [ ] Test that flattened fields get their defaults correctly
- [ ] Test that nested structs in config sections get defaults
- [ ] Test that subcommand args get their defaults