### PR TITLE
Add facet-styx support via optional `styx` feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +610,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-styx"
+version = "1.0.1"
+source = "git+https://github.com/bearcove/styx?branch=main#28a48449b4cd8c2aadc00829da5d23b46d4e4874"
+dependencies = [
+ "ariadne",
+ "facet",
+ "facet-core",
+ "facet-format",
+ "facet-reflect",
+ "serde_json",
+ "styx-format",
+ "styx-parse",
+ "styx-tree",
+]
+
+[[package]]
 name = "facet-testhelpers"
 version = "0.43.2"
 source = "git+https://github.com/facet-rs/facet?branch=main#a03551d849797da8457867a1a1cd6cc4947cad4b"
@@ -645,6 +667,7 @@ dependencies = [
  "facet-reflect",
  "facet-showcase",
  "facet-solver",
+ "facet-styx",
  "facet-testhelpers",
  "figue-attrs",
  "heck",
@@ -728,6 +751,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -865,7 +894,7 @@ dependencies = [
  "equivalent",
  "foldhash",
  "hashbrown 0.16.1",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1355,6 +1384,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1416,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1545,6 +1592,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "styx-cst"
+version = "1.0.1"
+source = "git+https://github.com/bearcove/styx?branch=main#28a48449b4cd8c2aadc00829da5d23b46d4e4874"
+dependencies = [
+ "rowan",
+ "styx-parse",
+]
+
+[[package]]
+name = "styx-format"
+version = "1.0.1"
+source = "git+https://github.com/bearcove/styx?branch=main#28a48449b4cd8c2aadc00829da5d23b46d4e4874"
+dependencies = [
+ "rowan",
+ "styx-cst",
+ "styx-parse",
+ "styx-tree",
+]
+
+[[package]]
+name = "styx-parse"
+version = "1.0.1"
+source = "git+https://github.com/bearcove/styx?branch=main#28a48449b4cd8c2aadc00829da5d23b46d4e4874"
+
+[[package]]
+name = "styx-tree"
+version = "1.0.1"
+source = "git+https://github.com/bearcove/styx?branch=main#28a48449b4cd8c2aadc00829da5d23b46d4e4874"
+dependencies = [
+ "ariadne",
+ "styx-parse",
+]
+
+[[package]]
 name = "supports-color"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1704,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thread_local"
@@ -1798,7 +1885,7 @@ checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
 dependencies = [
  "mutants",
  "proc-macro2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ facet = { git = "https://github.com/facet-rs/facet", branch = "main", version = 
 facet-core = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
 facet-format = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
 facet-json = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
+facet-styx = { git = "https://github.com/bearcove/styx", branch = "main", version = "1.0", optional = true }
 facet-reflect = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
 facet-pretty = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
 facet-error = { git = "https://github.com/facet-rs/facet", branch = "main", version = "0.43" }
@@ -63,6 +64,7 @@ default = ["rich-diagnostics"]
 rich-diagnostics = []
 doc = ["facet/doc"]
 tracing = ["facet-reflect/tracing", "facet-json/tracing", "facet-format/tracing"]
+styx = ["dep:facet-styx"]
 
 [[example]]
 name = "args_showcase"

--- a/src/enum_conflicts.rs
+++ b/src/enum_conflicts.rs
@@ -72,21 +72,13 @@ pub fn detect_enum_conflicts(value: &ConfigValue, schema: &Schema) -> Vec<EnumCo
     let mut conflicts = Vec::new();
 
     // Check config struct if present
-    if let Some(config_schema) = schema.config() {
-        if let Some(field_name) = config_schema.field_name() {
-            // Get the config value from the root object
-            if let ConfigValue::Object(sourced) = value {
-                if let Some(config_value) = sourced.value.get(field_name) {
-                    let mut path = vec![field_name.to_string()];
-                    check_struct_for_conflicts(
-                        config_value,
-                        config_schema,
-                        &mut path,
-                        &mut conflicts,
-                    );
-                }
-            }
-        }
+    if let Some(config_schema) = schema.config()
+        && let Some(field_name) = config_schema.field_name()
+        && let ConfigValue::Object(sourced) = value
+        && let Some(config_value) = sourced.value.get(field_name)
+    {
+        let mut path = vec![field_name.to_string()];
+        check_struct_for_conflicts(config_value, config_schema, &mut path, &mut conflicts);
     }
 
     conflicts
@@ -386,7 +378,10 @@ mod tests {
         let schema = Schema::from_shape(ArgsWithEnumConfig::SHAPE).unwrap();
         let conflicts = detect_enum_conflicts(&value, &schema);
 
-        assert!(conflicts.is_empty(), "should have no conflicts: {conflicts:?}");
+        assert!(
+            conflicts.is_empty(),
+            "should have no conflicts: {conflicts:?}"
+        );
     }
 
     #[test]
@@ -457,7 +452,8 @@ mod tests {
 
         // Should mention provenance sources
         assert!(
-            msg.contains("MYAPP__STORAGE__S3__BUCKET") || msg.contains("--config.storage.gcp.project"),
+            msg.contains("MYAPP__STORAGE__S3__BUCKET")
+                || msg.contains("--config.storage.gcp.project"),
             "error should mention provenance: {msg}"
         );
     }
@@ -527,7 +523,11 @@ mod tests {
         let schema = Schema::from_shape(ArgsWithOptionalEnumConfig::SHAPE).unwrap();
         let conflicts = detect_enum_conflicts(&value, &schema);
 
-        assert_eq!(conflicts.len(), 1, "optional enum should also detect conflicts");
+        assert_eq!(
+            conflicts.len(),
+            1,
+            "optional enum should also detect conflicts"
+        );
     }
 
     #[derive(Facet)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,14 @@ use facet_core::Facet;
 
 pub use builder::builder;
 pub use completions::{Shell, generate_completions, generate_completions_for_shape};
+#[cfg(feature = "styx")]
+pub use config_format::StyxFormat;
+pub use config_format::{ConfigFormat, ConfigFormatError, JsonFormat};
 pub use driver::{Driver, DriverError, DriverOutcome, DriverOutput, DriverReport};
 pub use error::{ArgsErrorKind, ArgsErrorWithInput};
 pub use help::{HelpConfig, generate_help, generate_help_for_shape};
 pub use layers::env::MockEnv;
+pub use layers::file::FormatRegistry;
 
 /// Parse command-line arguments from `std::env::args()`.
 ///


### PR DESCRIPTION
## Summary

- Adds `StyxFormat` implementing `ConfigFormat` for parsing `.styx` config files
- Uses `facet-styx` for deserialization into `ConfigValue`
- Gated behind optional `styx` feature flag to avoid adding dependencies by default
- Also exports `ConfigFormat`, `JsonFormat`, `ConfigFormatError`, and `FormatRegistry` publicly for users to register custom formats

## Usage

```toml
[dependencies]
figue = { version = "1.0", features = ["styx"] }
```

```rust
use figue::{FormatRegistry, StyxFormat};

let mut registry = FormatRegistry::with_defaults();
registry.register(StyxFormat);
```

## Test plan

- [x] Added tests for `StyxFormat` (extensions, parsing objects, arrays, nested structures)
- [x] All existing tests pass with and without the `styx` feature
- [x] Verified compilation without the `styx` feature (no regressions)

Fixes #41