### PR TITLE
Add 'did you mean...?' suggestions for typos using strsim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "insta",
  "owo-colors",
  "strip-ansi-escapes",
+ "strsim",
  "tempfile",
  "tracing",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1"
 ariadne = "0.6"
 unicode-width = "0.2.2"
 strip-ansi-escapes = "0.2.1"
+strsim = "0.11"
 insta = "1"
 tempfile = "3"
 

--- a/crates/figue/Cargo.toml
+++ b/crates/figue/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 ariadne.workspace = true
 unicode-width.workspace = true
 strip-ansi-escapes.workspace = true
+strsim.workspace = true
 
 [dev-dependencies]
 facet-format = { workspace = true, features = ["tracing"] }

--- a/crates/figue/src/layers/file.rs
+++ b/crates/figue/src/layers/file.rs
@@ -345,7 +345,15 @@ impl<'a> FileParseContext<'a> {
                     let error_msgs: Vec<String> = builder
                         .unused_keys()
                         .iter()
-                        .map(|uk| format!("unknown configuration key: {}", uk.key.join(".")))
+                        .map(|uk| {
+                            let suggestion =
+                                crate::suggest::suggest_config_path(config_schema, &uk.key);
+                            format!(
+                                "unknown configuration key: {}{}",
+                                uk.key.join("."),
+                                suggestion
+                            )
+                        })
                         .collect();
                     for msg in error_msgs {
                         builder.error(msg);
@@ -353,10 +361,8 @@ impl<'a> FileParseContext<'a> {
                 }
 
                 // Get the output from the builder
-                let mut output = builder.into_output_with_value(
-                    self.value.clone(),
-                    config_schema.field_name(),
-                );
+                let mut output =
+                    builder.into_output_with_value(self.value.clone(), config_schema.field_name());
 
                 // Prepend any early diagnostics (file read errors, etc.)
                 let mut all_diagnostics = self.early_diagnostics;

--- a/crates/figue/src/lib.rs
+++ b/crates/figue/src/lib.rs
@@ -36,6 +36,7 @@ pub(crate) mod reflection;
 pub(crate) mod schema;
 pub(crate) mod span;
 pub(crate) mod span_registry;
+pub(crate) mod suggest;
 pub(crate) mod value_builder;
 
 use facet_core::Facet;

--- a/crates/figue/src/suggest.rs
+++ b/crates/figue/src/suggest.rs
@@ -1,0 +1,231 @@
+//! String similarity suggestions for typos using Jaro-Winkler distance.
+
+/// Minimum similarity threshold for suggestions (Jaro-Winkler).
+const SIMILARITY_THRESHOLD: f64 = 0.8;
+
+/// Find the best matching candidate for a query string.
+///
+/// Returns the best match if:
+/// - There is at least one candidate with similarity >= `SIMILARITY_THRESHOLD`
+/// - Case-insensitive matching is used for comparison
+///
+/// Returns `None` if no good match is found.
+pub fn find_best_match<'a>(
+    query: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let query_lower = query.to_lowercase();
+
+    candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            let candidate_lower = candidate.to_lowercase();
+            let similarity = strsim::jaro_winkler(&query_lower, &candidate_lower);
+            if similarity >= SIMILARITY_THRESHOLD {
+                Some((candidate, similarity))
+            } else {
+                None
+            }
+        })
+        .max_by(|(_, sim_a), (_, sim_b)| {
+            sim_a
+                .partial_cmp(sim_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(candidate, _)| candidate)
+}
+
+/// Format a "did you mean...?" suggestion if a good match is found.
+///
+/// Returns an empty string if no good match exists.
+pub fn format_suggestion<'a>(query: &str, candidates: impl IntoIterator<Item = &'a str>) -> String {
+    match find_best_match(query, candidates) {
+        Some(suggestion) => format!(". Did you mean '{suggestion}'?"),
+        None => String::new(),
+    }
+}
+
+/// Try to suggest a similar path for an unknown config key.
+///
+/// Walks through the path segments and attempts to find which segment
+/// doesn't match the schema. Returns a suggestion for the failing segment
+/// if one can be found.
+pub fn suggest_config_path(schema: &crate::schema::ConfigStructSchema, path: &[String]) -> String {
+    use crate::schema::ConfigValueSchema;
+
+    if path.is_empty() {
+        return String::new();
+    }
+
+    // We need to track the current struct schema we're navigating
+    let mut current_struct = Some(schema);
+    let mut current_enum_variants: Option<Vec<&str>> = None;
+
+    for (i, segment) in path.iter().enumerate() {
+        let segment_lower = segment.to_lowercase();
+
+        // Determine what we're matching against
+        if let Some(enum_variants) = &current_enum_variants {
+            // We're looking for an enum variant
+            let found = enum_variants
+                .iter()
+                .any(|v| v.to_lowercase() == segment_lower);
+            if !found {
+                return format_suggestion(segment, enum_variants.iter().copied());
+            }
+            // TODO: Handle struct variants - for now, stop here
+            current_enum_variants = None;
+            current_struct = None;
+            continue;
+        }
+
+        if let Some(struct_schema) = current_struct {
+            let fields = struct_schema.fields();
+            let field_names: Vec<&str> = fields.keys().map(|s| s.as_str()).collect();
+
+            // Check if this segment exists (case-insensitive)
+            let matching_field = fields
+                .iter()
+                .find(|(k, _)| k.to_lowercase() == segment_lower);
+
+            if matching_field.is_none() {
+                // This is the failing segment - try to suggest an alternative
+                return format_suggestion(segment, field_names.iter().copied());
+            }
+
+            // Get the next level of fields if there are more segments
+            if i + 1 < path.len() {
+                let (_, field_schema) = matching_field.unwrap();
+                let value_schema = unwrap_option(field_schema.value());
+
+                match value_schema {
+                    ConfigValueSchema::Struct(s) => {
+                        current_struct = Some(s);
+                        current_enum_variants = None;
+                    }
+                    ConfigValueSchema::Enum(e) => {
+                        current_struct = None;
+                        current_enum_variants =
+                            Some(e.variants().keys().map(|s| s.as_str()).collect());
+                    }
+                    _ => {
+                        // Can't navigate further (leaf or array)
+                        return String::new();
+                    }
+                }
+            }
+        } else {
+            // We're in an unknown state, can't suggest
+            return String::new();
+        }
+    }
+
+    String::new()
+}
+
+/// Helper to unwrap Option wrapper in ConfigValueSchema
+fn unwrap_option(schema: &crate::schema::ConfigValueSchema) -> &crate::schema::ConfigValueSchema {
+    use crate::schema::ConfigValueSchema;
+    match schema {
+        ConfigValueSchema::Option { value, .. } => unwrap_option(value),
+        other => other,
+    }
+}
+
+/// Suggest a similar CLI flag name.
+///
+/// Takes a flag name (in kebab-case from the CLI) and all available flag names
+/// (will be converted to kebab-case for comparison).
+pub fn suggest_flag<'a>(query: &str, flag_names: impl IntoIterator<Item = &'a str>) -> String {
+    use heck::ToKebabCase as _;
+
+    // Convert all flag names to kebab-case for comparison
+    let candidates: Vec<(String, &'a str)> = flag_names
+        .into_iter()
+        .map(|name| (name.to_kebab_case(), name))
+        .collect();
+
+    // Find best match
+    let query_lower = query.to_lowercase();
+    let best_match = candidates
+        .iter()
+        .filter_map(|(kebab, original)| {
+            let similarity = strsim::jaro_winkler(&query_lower, &kebab.to_lowercase());
+            if similarity >= SIMILARITY_THRESHOLD {
+                Some((kebab.as_str(), *original, similarity))
+            } else {
+                None
+            }
+        })
+        .max_by(|(_, _, sim_a), (_, _, sim_b)| {
+            sim_a
+                .partial_cmp(sim_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(kebab, _, _)| kebab);
+
+    match best_match {
+        Some(suggestion) => format!(". Did you mean '--{suggestion}'?"),
+        None => String::new(),
+    }
+}
+
+/// Suggest a similar subcommand name.
+pub fn suggest_subcommand<'a>(
+    query: &str,
+    subcommand_names: impl IntoIterator<Item = &'a str>,
+) -> String {
+    match find_best_match(query, subcommand_names) {
+        Some(suggestion) => format!(". Did you mean '{suggestion}'?"),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_best_match_exact() {
+        let candidates = ["Debug", "Info", "Warn", "Error"];
+        assert_eq!(find_best_match("Debug", candidates), Some("Debug"));
+    }
+
+    #[test]
+    fn test_find_best_match_typo() {
+        let candidates = ["Debug", "Info", "Warn", "Error"];
+        // "Debugg" should match "Debug"
+        assert_eq!(find_best_match("Debugg", candidates), Some("Debug"));
+        // "Errror" should match "Error"
+        assert_eq!(find_best_match("Errror", candidates), Some("Error"));
+    }
+
+    #[test]
+    fn test_find_best_match_case_insensitive() {
+        let candidates = ["Debug", "Info", "Warn", "Error"];
+        assert_eq!(find_best_match("debug", candidates), Some("Debug"));
+        assert_eq!(find_best_match("DEBUG", candidates), Some("Debug"));
+    }
+
+    #[test]
+    fn test_find_best_match_no_match() {
+        let candidates = ["Debug", "Info", "Warn", "Error"];
+        // Completely different string
+        assert_eq!(find_best_match("XYZ123", candidates), None);
+    }
+
+    #[test]
+    fn test_format_suggestion_with_match() {
+        let candidates = ["port", "host", "timeout"];
+        assert_eq!(
+            format_suggestion("portt", candidates),
+            ". Did you mean 'port'?"
+        );
+    }
+
+    #[test]
+    fn test_format_suggestion_no_match() {
+        let candidates = ["port", "host", "timeout"];
+        assert_eq!(format_suggestion("completely_different", candidates), "");
+    }
+}

--- a/crates/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_unknown_flag_with_suggestion.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_unknown_flag_with_suggestion.snap
@@ -1,13 +1,13 @@
 ---
-source: tests/integration/ariadne.rs
+source: crates/figue/tests/integration/ariadne.rs
 expression: ariadne_output
 ---
-Error: unknown flag: --c0ncurrency
+Error: unknown flag: --c0ncurrency. Did you mean '--concurrency'?
    ╭─[ <cli>:1:1 ]
    │
  1 │ --c0ncurrency 4
    │ ──────┬──────  
-   │       ╰──────── unknown flag: --c0ncurrency
+   │       ╰──────── unknown flag: --c0ncurrency. Did you mean '--concurrency'?
 ───╯
 Error: unexpected argument: 4
    ╭─[ <cli>:1:15 ]

--- a/crates/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_unknown_subcommand.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__ariadne__ariadne_unknown_subcommand.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/ariadne.rs
+source: crates/figue/tests/integration/ariadne.rs
 expression: ariadne_output
 ---
-Error: unexpected argument: buidl
+Error: unexpected argument: buidl. Did you mean 'build'?
    ╭─[ <cli>:1:1 ]
    │
  1 │ buidl
    │ ──┬──  
-   │   ╰──── unexpected argument: buidl
+   │   ╰──── unexpected argument: buidl. Did you mean 'build'?
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__err__error_unknown_argument.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__err__error_unknown_argument.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/err.rs
+source: crates/figue/tests/integration/err.rs
 expression: "$crate :: common :: strip_ansi(& err.to_string())"
 ---
-Error: unknown flag: --c0ncurrency
+Error: unknown flag: --c0ncurrency. Did you mean '--concurrency'?
    ╭─[ <cli>:1:1 ]
    │
  1 │ --c0ncurrency
    │ ──────┬──────  
-   │       ╰──────── unknown flag: --c0ncurrency
+   │       ╰──────── unknown flag: --c0ncurrency. Did you mean '--concurrency'?
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__sequence__doubledash_flags_before_dd.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__sequence__doubledash_flags_before_dd.snap
@@ -1,11 +1,11 @@
 ---
-source: tests/integration/sequence.rs
+source: crates/figue/tests/integration/sequence.rs
 expression: "$crate :: common :: strip_ansi(& err.to_string())"
 ---
-Error: unknown flag: --baz
+Error: unknown flag: --baz. Did you mean '--bar'?
    ╭─[ <cli>:1:13 ]
    │
  1 │ --foo --bar --baz
    │             ──┬──  
-   │               ╰──── unknown flag: --baz
+   │               ╰──── unknown flag: --baz. Did you mean '--bar'?
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__subcommand__wrong_argument_style_for_nested_subcommand.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__subcommand__wrong_argument_style_for_nested_subcommand.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/integration/subcommand.rs
+source: crates/figue/tests/integration/subcommand.rs
 expression: "$crate :: common :: strip_ansi(& err.to_string())"
 ---
 Error: unknown flag: --action
@@ -9,10 +9,10 @@ Error: unknown flag: --action
    │    ────┬───  
    │        ╰───── unknown flag: --action
 ───╯
-Error: unexpected argument: gen
+Error: unexpected argument: gen. Did you mean 'generate'?
    ╭─[ <cli>:1:13 ]
    │
  1 │ ci --action gen
    │             ─┬─  
-   │              ╰─── unexpected argument: gen
+   │              ╰─── unexpected argument: gen. Did you mean 'generate'?
 ───╯


### PR DESCRIPTION
## Summary

Fixes #36

- Adds `strsim` crate dependency for string similarity matching using Jaro-Winkler algorithm
- Creates new `suggest.rs` module with helper functions for finding similar strings
- Adds "Did you mean...?" suggestions to:
  - **Enum variants** (env.rs, file.rs via value_builder.rs) - e.g., `unknown variant 'Debugg'. Did you mean 'Debug'?`
  - **Config field names** (env.rs, file.rs) - e.g., `unknown configuration key: portt. Did you mean 'port'?`
  - **CLI flags** (cli.rs) - e.g., `unknown flag: --verbse. Did you mean '--verbose'?`
  - **Subcommands** (cli.rs) - e.g., `unexpected argument: buidl. Did you mean 'build'?`

Suggestions only appear when similarity is above 0.8 threshold (Jaro-Winkler).

## Test plan

- [x] All existing tests pass (468 tests)
- [x] Updated existing tests to verify suggestions appear
- [x] Updated snapshot tests to reflect new error messages
- [x] Clippy passes with no warnings