### PR TITLE
Support multiple config roots

### DIFF
--- a/crates/figue/src/config_value_parser.rs
+++ b/crates/figue/src/config_value_parser.rs
@@ -96,8 +96,8 @@ pub(crate) fn fill_defaults_from_schema(value: &ConfigValue, schema: &Schema) ->
     // Fill defaults for args-level fields (already flattened in schema.args())
     fill_defaults_from_arg_level(&mut new_map, schema.args(), "");
 
-    // Fill defaults for config field if present
-    if let Some(config_schema) = schema.config() {
+    // Fill defaults for config fields if present
+    for config_schema in schema.configs() {
         let config_field_name = config_schema.field_name().unwrap_or("config").to_string();
 
         if let Some(config_value) = new_map.get(&config_field_name) {

--- a/crates/figue/src/driver.rs
+++ b/crates/figue/src/driver.rs
@@ -30,7 +30,7 @@ use crate::config_value_parser::{fill_defaults_from_schema, from_config_value};
 use crate::dump::dump_config_with_schema;
 use crate::enum_conflicts::detect_enum_conflicts;
 use crate::env_subst::{EnvSubstError, RealEnv, substitute_env_vars};
-use crate::help::generate_help_for_subcommand;
+use crate::help::generate_help_for_subcommand_with_config_formats;
 use crate::layers::{cli::parse_cli, env::parse_env, file::parse_file};
 use crate::merge::merge_layers;
 use crate::missing::{
@@ -140,6 +140,14 @@ impl<T: Facet<'static>> Driver<T> {
         }
     }
 
+    fn config_file_extensions(&self) -> Vec<&str> {
+        self.config
+            .file_config
+            .as_ref()
+            .map(|file_config| file_config.registry.extensions())
+            .unwrap_or_else(|| vec!["json"])
+    }
+
     /// Execute the driver and return an outcome.
     ///
     /// The returned `DriverOutcome` must be handled explicitly:
@@ -232,10 +240,12 @@ impl<T: Facet<'static>> Driver<T> {
                     Vec::new()
                 };
 
-                let text = generate_help_for_subcommand(
+                let config_file_extensions = self.config_file_extensions();
+                let text = generate_help_for_subcommand_with_config_formats(
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
+                    &config_file_extensions,
                 );
                 return DriverOutcome::err(DriverError::Help {
                     text,
@@ -340,13 +350,16 @@ impl<T: Facet<'static>> Driver<T> {
         // Phase 2.5: Environment variable substitution
         // Substitute ${VAR} patterns in string values where env_subst is enabled
         let mut merged_value = merged.value;
-        if let Some(config_schema) = self.config.schema.config()
-            && let ConfigValue::Object(ref mut sourced_fields) = merged_value
-            && let Some(config_field_name) = config_schema.field_name()
-            && let Some(config_value) = sourced_fields.value.get_mut(&config_field_name.to_string())
-            && let Err(e) = substitute_env_vars(config_value, config_schema, &RealEnv)
-        {
-            return DriverOutcome::err(DriverError::EnvSubst { error: e });
+        if let ConfigValue::Object(ref mut sourced_fields) = merged_value {
+            for config_schema in self.config.schema.configs() {
+                if let Some(config_field_name) = config_schema.field_name()
+                    && let Some(config_value) =
+                        sourced_fields.value.get_mut(&config_field_name.to_string())
+                    && let Err(e) = substitute_env_vars(config_value, config_schema, &RealEnv)
+                {
+                    return DriverOutcome::err(DriverError::EnvSubst { error: e });
+                }
+            }
         }
         tracing::debug!(merged_value = ?merged_value, "driver: after env_subst");
 
@@ -439,7 +452,13 @@ impl<T: Facet<'static>> Driver<T> {
                     .cloned()
                     .unwrap_or_default();
 
-                let help = generate_help_for_subcommand(&self.config.schema, &[], &help_config);
+                let config_file_extensions = self.config_file_extensions();
+                let help = generate_help_for_subcommand_with_config_formats(
+                    &self.config.schema,
+                    &[],
+                    &help_config,
+                    &config_file_extensions,
+                );
                 return DriverOutcome::err(DriverError::Help {
                     text: help,
                     suggestion: None,
@@ -475,10 +494,12 @@ impl<T: Facet<'static>> Driver<T> {
                     Vec::new()
                 };
 
-                let help = generate_help_for_subcommand(
+                let config_file_extensions = self.config_file_extensions();
+                let help = generate_help_for_subcommand_with_config_formats(
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
+                    &config_file_extensions,
                 );
                 return DriverOutcome::err(DriverError::Help {
                     text: help,
@@ -515,10 +536,12 @@ impl<T: Facet<'static>> Driver<T> {
                     Vec::new()
                 };
 
-                let help = generate_help_for_subcommand(
+                let config_file_extensions = self.config_file_extensions();
+                let help = generate_help_for_subcommand_with_config_formats(
                     &self.config.schema,
                     &subcommand_path,
                     &help_config,
+                    &config_file_extensions,
                 );
 
                 // Build the Ariadne corrected-command suggestion so the user
@@ -580,13 +603,27 @@ impl<T: Facet<'static>> Driver<T> {
 
                 // Format the summary of unknown keys with suggestions
                 let unknown_summary = if has_unknown {
-                    let config_schema = self.config.schema.config();
                     let unknown_list: Vec<String> = unknown_keys
                         .iter()
                         .map(|uk| {
                             let source = uk.provenance.source_description();
-                            let suggestion = config_schema
-                                .map(|cs| crate::suggest::suggest_config_path(cs, &uk.key))
+                            let suggestion = self
+                                .config
+                                .schema
+                                .configs()
+                                .iter()
+                                .find_map(|cs| {
+                                    let key = if self.config.schema.configs().len() > 1 {
+                                        let field_name = cs.field_name()?;
+                                        uk.key
+                                            .strip_prefix(&[field_name.to_string()][..])
+                                            .unwrap_or(&uk.key)
+                                    } else {
+                                        &uk.key
+                                    };
+                                    let suggestion = crate::suggest::suggest_config_path(cs, key);
+                                    (!suggestion.is_empty()).then_some(suggestion)
+                                })
                                 .unwrap_or_default();
                             format!("  {} (from {}){}", uk.key.join("."), source, suggestion)
                         })
@@ -1460,6 +1497,22 @@ mod tests {
         builtins: FigueBuiltins,
     }
 
+    #[derive(Facet, Debug)]
+    struct ArgsWithConfigAndBuiltins {
+        /// Application configuration
+        #[facet(figue::config)]
+        config: HelpTestConfig,
+
+        #[facet(flatten)]
+        builtins: FigueBuiltins,
+    }
+
+    #[derive(Facet, Debug)]
+    struct HelpTestConfig {
+        #[facet(default = "localhost")]
+        host: String,
+    }
+
     #[test]
     fn test_driver_help_flag() {
         let config = builder::<ArgsWithBuiltins>()
@@ -1501,6 +1554,27 @@ mod tests {
             matches!(result, Err(DriverError::Help { .. })),
             "expected DriverError::Help"
         );
+    }
+
+    #[test]
+    fn test_driver_help_shows_registered_config_file_formats() {
+        let config = builder::<ArgsWithConfigAndBuiltins>()
+            .unwrap()
+            .cli(|cli| cli.args(["--help"]))
+            .file(|file| file.format(crate::JsoncFormat))
+            .build();
+
+        let driver = Driver::new(config);
+        let result = driver.run().into_result();
+
+        match result {
+            Err(DriverError::Help { text, .. }) => {
+                let text = strip_ansi_escapes::strip_str(&text);
+                assert!(text.contains("--config <FILE>"));
+                assert!(text.contains("Supported file formats: .json, .jsonc."));
+            }
+            other => panic!("expected DriverError::Help, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/figue/src/dump.rs
+++ b/crates/figue/src/dump.rs
@@ -138,15 +138,31 @@ pub(crate) fn dump_config_with_schema(
 // ============================================================================
 
 fn write_sources_header(w: &mut impl Write, file_resolution: &FileResolution, schema: &Schema) {
-    let config = schema.config();
-    let config_field_name = config.and_then(|c| c.field_name()).unwrap_or("settings");
-    let env_prefix = config.and_then(|c| c.env_prefix());
+    let config_field_names: Vec<&str> = schema
+        .configs()
+        .iter()
+        .filter_map(|c| c.field_name())
+        .collect();
+    let env_prefixes: Vec<&str> = schema
+        .configs()
+        .iter()
+        .filter_map(|c| c.env_prefix())
+        .collect();
+    let cli_pattern = if config_field_names.is_empty() {
+        "--settings.*".to_string()
+    } else {
+        config_field_names
+            .iter()
+            .map(|name| format!("--{}.*", name))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
 
     writeln!(w, "Sources:").ok();
 
     // Count how many sources we have to determine which is last
     let has_files = !file_resolution.paths.is_empty() || file_resolution.had_explicit;
-    let has_env = env_prefix.is_some();
+    let has_env = !env_prefixes.is_empty();
     let has_cli = true;
     let has_defaults = true;
 
@@ -219,15 +235,20 @@ fn write_sources_header(w: &mut impl Write, file_resolution: &FileResolution, sc
         writeln!(w, "{}file: (none - explicit --config not provided)", branch).ok();
     }
 
-    if let Some(prefix) = env_prefix {
+    if has_env {
         current_source += 1;
         let is_last_source = current_source == sources_count;
         let branch = if is_last_source { "└─ " } else { "├─ " };
+        let env_pattern = env_prefixes
+            .iter()
+            .map(|prefix| format!("${}__*", prefix))
+            .collect::<Vec<_>>()
+            .join(", ");
         writeln!(
             w,
             "{}env {}",
             branch,
-            format!("${}__*", prefix).if_supports_color(Stdout, |text| text.yellow())
+            env_pattern.if_supports_color(Stdout, |text| text.yellow())
         )
         .ok();
     }
@@ -240,7 +261,7 @@ fn write_sources_header(w: &mut impl Write, file_resolution: &FileResolution, sc
             w,
             "{}cli {}",
             branch,
-            format!("--{}.*", config_field_name).if_supports_color(Stdout, |text| text.cyan())
+            cli_pattern.if_supports_color(Stdout, |text| text.cyan())
         )
         .ok();
     }
@@ -287,12 +308,14 @@ fn build_dump_tree(value: &ConfigValue, schema: &Schema, opts: &FormatOptions) -
     }
 
     // Config fields
-    if let Some(config_schema) = schema.config() {
+    let group_config_roots = schema.configs().len() > 1;
+    for config_schema in schema.configs() {
         let config_field_name = config_schema.field_name().unwrap_or("config");
         if let Some(ConfigValue::Object(config_sourced)) = sourced.value.get(config_field_name) {
+            let mut children = Vec::new();
             for (field_name, field_schema) in config_schema.fields() {
                 if let Some(field_value) = config_sourced.value.get(field_name.as_str()) {
-                    entries.push(build_entry_from_schema(
+                    children.push(build_entry_from_schema(
                         field_name,
                         field_value,
                         field_schema.value(),
@@ -303,11 +326,16 @@ fn build_dump_tree(value: &ConfigValue, schema: &Schema, opts: &FormatOptions) -
                     let is_optional =
                         matches!(field_schema.value(), ConfigValueSchema::Option { .. });
                     if is_optional {
-                        entries.push(DumpEntry::default_value(field_name));
+                        children.push(DumpEntry::default_value(field_name));
                     } else {
-                        entries.push(DumpEntry::missing(field_name));
+                        children.push(DumpEntry::missing(field_name));
                     }
                 }
+            }
+            if group_config_roots {
+                entries.push(DumpEntry::group(config_field_name, children));
+            } else {
+                entries.extend(children);
             }
         }
     }

--- a/crates/figue/src/enum_conflicts.rs
+++ b/crates/figue/src/enum_conflicts.rs
@@ -72,13 +72,15 @@ pub fn detect_enum_conflicts(value: &ConfigValue, schema: &Schema) -> Vec<EnumCo
     let mut conflicts = Vec::new();
 
     // Check config struct if present
-    if let Some(config_schema) = schema.config()
-        && let Some(field_name) = config_schema.field_name()
-        && let ConfigValue::Object(sourced) = value
-        && let Some(config_value) = sourced.value.get(field_name)
-    {
-        let mut path = vec![field_name.to_string()];
-        check_struct_for_conflicts(config_value, config_schema, &mut path, &mut conflicts);
+    if let ConfigValue::Object(sourced) = value {
+        for config_schema in schema.configs() {
+            if let Some(field_name) = config_schema.field_name()
+                && let Some(config_value) = sourced.value.get(field_name)
+            {
+                let mut path = vec![field_name.to_string()];
+                check_struct_for_conflicts(config_value, config_schema, &mut path, &mut conflicts);
+            }
+        }
     }
 
     conflicts

--- a/crates/figue/src/extract.rs
+++ b/crates/figue/src/extract.rs
@@ -107,7 +107,11 @@ pub fn extract_requirements<R: Facet<'static>>(
     let mut extracted_values: ObjectMap = IndexMap::default();
 
     // Get env prefix from schema if available
-    let env_prefix = schema.config().and_then(|c| c.env_prefix());
+    let env_prefix = if schema.configs().len() == 1 {
+        schema.configs()[0].env_prefix()
+    } else {
+        None
+    };
 
     for field in struct_type.fields {
         let field_name = field.name;

--- a/crates/figue/src/help.rs
+++ b/crates/figue/src/help.rs
@@ -4,13 +4,18 @@
 //! including doc comments, field names, and attribute information.
 
 use crate::missing::normalize_program_name;
-use crate::schema::{ArgLevelSchema, ArgSchema, Schema, Subcommand};
+use crate::schema::{
+    ArgLevelSchema, ArgSchema, ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, Schema,
+    Subcommand,
+};
 use facet_core::Facet;
 use heck::ToKebabCase;
 use owo_colors::OwoColorize;
 use owo_colors::Stream::Stdout;
 use std::string::String;
 use std::vec::Vec;
+
+const DEFAULT_CONFIG_FILE_EXTENSIONS: &[&str] = &["json"];
 
 /// Generate help text for a Facet type.
 ///
@@ -81,6 +86,20 @@ pub fn generate_help_for_subcommand(
     subcommand_path: &[String],
     config: &HelpConfig,
 ) -> String {
+    generate_help_for_subcommand_with_config_formats(
+        schema,
+        subcommand_path,
+        config,
+        DEFAULT_CONFIG_FILE_EXTENSIONS,
+    )
+}
+
+pub(crate) fn generate_help_for_subcommand_with_config_formats(
+    schema: &Schema,
+    subcommand_path: &[String],
+    config: &HelpConfig,
+    config_file_extensions: &[&str],
+) -> String {
     let program_name = config
         .program_name
         .clone()
@@ -92,7 +111,7 @@ pub fn generate_help_for_subcommand(
         .unwrap_or_else(|| "program".to_string());
 
     if subcommand_path.is_empty() {
-        return generate_help_from_schema(schema, &program_name, config);
+        return generate_help_from_schema(schema, &program_name, config, config_file_extensions);
     }
 
     // Navigate to the subcommand
@@ -112,7 +131,12 @@ pub fn generate_help_for_subcommand(
             current_args = sub.args();
         } else {
             // Subcommand not found, fall back to root help
-            return generate_help_from_schema(schema, &program_name, config);
+            return generate_help_from_schema(
+                schema,
+                &program_name,
+                config,
+                config_file_extensions,
+            );
         }
     }
 
@@ -135,7 +159,12 @@ pub fn generate_help_for_subcommand(
 }
 
 /// Generate help from a built Schema.
-fn generate_help_from_schema(schema: &Schema, program_name: &str, config: &HelpConfig) -> String {
+fn generate_help_from_schema(
+    schema: &Schema,
+    program_name: &str,
+    config: &HelpConfig,
+    config_file_extensions: &[&str],
+) -> String {
     let mut out = String::new();
 
     // Program name and version
@@ -167,7 +196,14 @@ fn generate_help_from_schema(schema: &Schema, program_name: &str, config: &HelpC
 
     out.push('\n');
 
-    generate_arg_level_help(&mut out, schema.args(), program_name, config);
+    generate_arg_level_help(
+        &mut out,
+        schema.args(),
+        schema.configs(),
+        program_name,
+        config,
+        config_file_extensions,
+    );
 
     out
 }
@@ -208,7 +244,14 @@ fn generate_help_for_subcommand_level(
 
     out.push('\n');
 
-    generate_arg_level_help(&mut out, args, full_command, config);
+    generate_arg_level_help(
+        &mut out,
+        args,
+        &[],
+        full_command,
+        config,
+        DEFAULT_CONFIG_FILE_EXTENSIONS,
+    );
 
     out
 }
@@ -256,8 +299,10 @@ fn wrap_text(text: &str, indent: &str, max_width: usize) -> String {
 fn generate_arg_level_help(
     out: &mut String,
     args: &ArgLevelSchema,
+    config_roots: &[ConfigStructSchema],
     program_name: &str,
     config: &HelpConfig,
+    config_file_extensions: &[&str],
 ) {
     // Separate positionals and named flags
     let mut positionals: Vec<&ArgSchema> = Vec::new();
@@ -275,7 +320,7 @@ fn generate_arg_level_help(
     out.push_str(&format!("{}:\n    ", "USAGE".yellow().bold()));
     out.push_str(program_name);
 
-    if !flags.is_empty() {
+    if !flags.is_empty() || !config_roots.is_empty() {
         out.push_str(" [OPTIONS]");
     }
 
@@ -308,10 +353,13 @@ fn generate_arg_level_help(
     }
 
     // Options
-    if !flags.is_empty() {
+    if !flags.is_empty() || !config_roots.is_empty() {
         out.push_str(&format!("{}:\n", "OPTIONS".yellow().bold()));
         for arg in &flags {
             write_arg_help(out, arg, config);
+        }
+        for config_root in config_roots {
+            write_config_help(out, config_root, config, config_file_extensions);
         }
         out.push('\n');
     }
@@ -324,6 +372,186 @@ fn generate_arg_level_help(
         }
         out.push('\n');
     }
+}
+
+/// Write help for a config root.
+fn write_config_help(
+    out: &mut String,
+    config_root: &ConfigStructSchema,
+    config: &HelpConfig,
+    config_file_extensions: &[&str],
+) {
+    let Some(name) = config_root.field_name() else {
+        return;
+    };
+    let cli_name = name.to_kebab_case();
+    let config_flag = format!("--{cli_name}");
+
+    out.push_str("        ");
+    out.push_str(&format!(
+        "{} <FILE>",
+        config_flag.if_supports_color(Stdout, |text| text.green())
+    ));
+    out.push('\n');
+    let file_help = config_root
+        .docs()
+        .summary()
+        .unwrap_or("Load configuration values from a file.");
+    out.push_str(&wrap_text(file_help, "            ", config.width));
+    out.push('\n');
+    out.push_str(&wrap_text(
+        &format_config_file_extensions(config_file_extensions),
+        "            ",
+        config.width,
+    ));
+    out.push('\n');
+
+    for item in config_override_help_items(&config_flag, config_root) {
+        write_config_override_help(out, &item, config);
+    }
+}
+
+fn format_config_file_extensions(extensions: &[&str]) -> String {
+    let mut unique = Vec::new();
+    for extension in extensions {
+        let extension = extension.trim_start_matches('.');
+        if !extension.is_empty()
+            && !unique
+                .iter()
+                .any(|existing: &&str| existing.eq_ignore_ascii_case(extension))
+        {
+            unique.push(extension);
+        }
+    }
+
+    if unique.is_empty() {
+        return "No config file formats are registered.".to_string();
+    }
+
+    let formatted = unique
+        .iter()
+        .map(|extension| format!(".{extension}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("Supported file formats: {formatted}.")
+}
+
+struct ConfigOverrideHelpItem {
+    flag: String,
+    placeholder: String,
+    help: Option<String>,
+}
+
+fn write_config_override_help(
+    out: &mut String,
+    item: &ConfigOverrideHelpItem,
+    config: &HelpConfig,
+) {
+    out.push_str("        ");
+    out.push_str(&format!(
+        "{} <{}>",
+        item.flag.if_supports_color(Stdout, |text| text.green()),
+        item.placeholder
+    ));
+    out.push('\n');
+
+    if let Some(help) = &item.help {
+        out.push_str(&wrap_text(help, "            ", config.width));
+        out.push('\n');
+    }
+}
+
+fn config_override_help_items(
+    config_flag: &str,
+    config_root: &ConfigStructSchema,
+) -> Vec<ConfigOverrideHelpItem> {
+    let mut items = Vec::new();
+    collect_config_struct_overrides(config_flag, config_root, Vec::new(), &mut items);
+    items
+}
+
+fn collect_config_struct_overrides(
+    config_flag: &str,
+    config_struct: &ConfigStructSchema,
+    path: Vec<String>,
+    items: &mut Vec<ConfigOverrideHelpItem>,
+) {
+    for (field_name, field) in config_struct.fields() {
+        let mut field_path = path.clone();
+        field_path.push(field_name.clone());
+        collect_config_field_override(config_flag, field_path, field, items);
+    }
+}
+
+fn collect_config_field_override(
+    config_flag: &str,
+    path: Vec<String>,
+    field: &ConfigFieldSchema,
+    items: &mut Vec<ConfigOverrideHelpItem>,
+) {
+    let help = field.docs().summary().map(str::to_string);
+    collect_config_value_overrides(config_flag, path, field.value(), help, items);
+}
+
+fn collect_config_value_overrides(
+    config_flag: &str,
+    path: Vec<String>,
+    value: &ConfigValueSchema,
+    help: Option<String>,
+    items: &mut Vec<ConfigOverrideHelpItem>,
+) {
+    match value.inner_if_option() {
+        ConfigValueSchema::Struct(config_struct) => {
+            collect_config_struct_overrides(config_flag, config_struct, path, items);
+        }
+        ConfigValueSchema::Vec(vec_schema) => {
+            let mut element_path = path;
+            element_path.push("<INDEX>".to_string());
+            collect_config_value_overrides(
+                config_flag,
+                element_path,
+                vec_schema.element(),
+                help,
+                items,
+            );
+        }
+        ConfigValueSchema::Enum(enum_schema) => {
+            let variants: Vec<&str> = enum_schema.variants().keys().map(String::as_str).collect();
+            if enum_schema
+                .variants()
+                .values()
+                .any(|variant| variant.fields().is_empty())
+            {
+                items.push(ConfigOverrideHelpItem {
+                    flag: config_override_flag(config_flag, &path),
+                    placeholder: variants.join(","),
+                    help: help.clone(),
+                });
+            }
+
+            for (variant_name, variant_schema) in enum_schema.variants() {
+                let mut variant_path = path.clone();
+                variant_path.push(variant_name.clone());
+                for (field_name, field) in variant_schema.fields() {
+                    let mut field_path = variant_path.clone();
+                    field_path.push(field_name.clone());
+                    collect_config_field_override(config_flag, field_path, field, items);
+                }
+            }
+        }
+        ConfigValueSchema::Leaf(_) => {
+            items.push(ConfigOverrideHelpItem {
+                flag: config_override_flag(config_flag, &path),
+                placeholder: value.type_identifier().to_uppercase(),
+                help,
+            });
+        }
+        ConfigValueSchema::Option { .. } => unreachable!("inner_if_option removes Option wrappers"),
+    }
+}
+
+fn config_override_flag(config_flag: &str, path: &[String]) -> String {
+    format!("{config_flag}.{}", path.join("."))
 }
 
 /// Write help for a single argument.
@@ -553,6 +781,66 @@ mod tests {
             !help.contains("SERVEARGS"),
             "help should NOT show SERVEARGS as an option value"
         );
+    }
+
+    #[test]
+    fn test_config_roots_appear_in_help() {
+        #[derive(Facet)]
+        struct Args {
+            /// Session configuration
+            #[facet(args::config, args::env_prefix = "BEE", rename = "cfg")]
+            cfg: SessionConfig,
+
+            /// Evaluation configuration
+            #[facet(args::config, args::env_prefix = "BEE_EVAL", rename = "eval")]
+            eval: EvalConfig,
+        }
+
+        #[derive(Facet)]
+        struct SessionConfig {
+            /// Session hostname
+            #[facet(default = "localhost")]
+            host: String,
+
+            /// Labels attached to this session
+            tags: Vec<String>,
+
+            server: ServerConfig,
+        }
+
+        #[derive(Facet)]
+        struct ServerConfig {
+            /// Server port
+            #[facet(default = 8080)]
+            port: u16,
+        }
+
+        #[derive(Facet)]
+        struct EvalConfig {
+            /// Number of evaluation samples
+            #[facet(default = 10)]
+            samples: u32,
+        }
+
+        let schema = Schema::from_shape(Args::SHAPE).unwrap();
+        let help = generate_help_for_subcommand(&schema, &[], &HelpConfig::default());
+        let help = strip_ansi_escapes::strip_str(&help);
+
+        assert!(help.contains("--cfg <FILE>"));
+        assert!(help.contains("Session configuration"));
+        assert!(help.contains("Supported file formats: .json."));
+        assert!(help.contains("--cfg.host <STRING>"));
+        assert!(help.contains("Session hostname"));
+        assert!(help.contains("--cfg.tags.<INDEX> <STRING>"));
+        assert!(help.contains("Labels attached to this session"));
+        assert!(help.contains("--cfg.server.port <U16>"));
+        assert!(help.contains("Server port"));
+        assert!(help.contains("--eval <FILE>"));
+        assert!(help.contains("Evaluation configuration"));
+        assert!(help.contains("--eval.samples <U32>"));
+        assert!(help.contains("Number of evaluation samples"));
+        assert!(!help.contains("--cfg.<KEY>"));
+        assert!(!help.contains("--eval.<KEY>"));
     }
 
     #[test]

--- a/crates/figue/src/layers/cli.rs
+++ b/crates/figue/src/layers/cli.rs
@@ -204,9 +204,8 @@ struct ParseContext<'a> {
     /// Stack of parent levels for the adoption agency algorithm.
     /// When parsing a subcommand, parent levels are pushed here so flags can bubble up.
     parent_stack: Vec<ParentLevel<'a>>,
-    /// ValueBuilder for config overrides (--config.foo.bar style).
-    /// Only present if the schema has a config field.
-    config_builder: Option<ValueBuilder<'a>>,
+    /// ValueBuilders for config overrides (--config.foo.bar style), keyed by config root field.
+    config_builders: IndexMap<String, ValueBuilder<'a>, RandomState>,
     /// Config file path captured from `--<config-field-name> <path>`.
     /// E.g., if the config field is named "config", this captures `--config /path/to/file.json`.
     config_file_path: Option<camino::Utf8PathBuf>,
@@ -227,7 +226,15 @@ impl<'a> ParseContext<'a> {
             }
         }
 
-        let config_builder = schema.config().map(ValueBuilder::new);
+        let config_builders = schema
+            .configs()
+            .iter()
+            .filter_map(|config_schema| {
+                config_schema
+                    .field_name()
+                    .map(|name| (name.to_string(), ValueBuilder::new(config_schema)))
+            })
+            .collect();
 
         Self {
             args,
@@ -239,7 +246,7 @@ impl<'a> ParseContext<'a> {
             counted: IndexMap::default(),
             arg_offsets,
             parent_stack: Vec::new(),
-            config_builder,
+            config_builders,
             config_file_path: None,
         }
     }
@@ -326,24 +333,34 @@ impl<'a> ParseContext<'a> {
         };
 
         // Check if this is a config override (e.g., --config.port)
-        if let Some(config_schema) = self.schema.config()
-            && let Some(config_field_name) = config_schema.field_name()
-            && flag_name.starts_with(config_field_name)
-            && flag_name.len() > config_field_name.len()
-            && flag_name.as_bytes()[config_field_name.len()] == b'.'
-        {
-            self.parse_config_override(arg, flag_name, inline_value, config_field_name);
-            return;
+        for config_schema in self.schema.configs() {
+            if let Some(config_field_name) = config_schema.field_name() {
+                let cli_root = config_field_name.to_kebab_case();
+                if flag_name.starts_with(&cli_root)
+                    && flag_name.len() > cli_root.len()
+                    && flag_name.as_bytes()[cli_root.len()] == b'.'
+                {
+                    self.parse_config_override(
+                        arg,
+                        flag_name,
+                        inline_value,
+                        &cli_root,
+                        config_field_name,
+                    );
+                    return;
+                }
+            }
         }
 
         // Check if this is the config file path flag (e.g., --config /path/to/file.json)
         // The flag name must match the config field's effective name (in kebab-case)
-        if let Some(config_schema) = self.schema.config()
-            && let Some(config_field_name) = config_schema.field_name()
-            && flag_name == config_field_name.to_kebab_case()
-        {
-            self.parse_config_file_path(arg, inline_value);
-            return;
+        for config_schema in self.schema.configs() {
+            if let Some(config_field_name) = config_schema.field_name()
+                && flag_name == config_field_name.to_kebab_case()
+            {
+                self.parse_config_file_path(arg, inline_value);
+                return;
+            }
         }
 
         // Look up in schema - Args::get converts schema keys to kebab-case for comparison
@@ -722,10 +739,11 @@ impl<'a> ParseContext<'a> {
         _arg: &str,
         flag_name: &str,
         inline_value: Option<&str>,
+        cli_root: &str,
         config_field_name: &str,
     ) {
         // Extract the path after "config."
-        let path_str = &flag_name[config_field_name.len() + 1..];
+        let path_str = &flag_name[cli_root.len() + 1..];
         let parts: Vec<&str> = path_str.split('.').collect();
 
         // Get the value
@@ -754,8 +772,8 @@ impl<'a> ParseContext<'a> {
         let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
         let leaf_value = LeafValue::String(value_str.to_string());
 
-        self.config_builder
-            .as_mut()
+        self.config_builders
+            .get_mut(config_field_name)
             .expect("config_builder must exist when parsing config overrides")
             .set(&path, leaf_value, Some(value_span), provenance);
     }
@@ -1095,20 +1113,21 @@ impl<'a> ParseContext<'a> {
         // Merge config builder output if present
         let mut unused_keys = Vec::new();
         let mut diagnostics = self.diagnostics;
+        let multiple_config_roots = self.config_builders.len() > 1;
 
-        if let Some(builder) = self.config_builder
-            && let Some(config_schema) = self.schema.config()
-        {
-            let config_field_name = config_schema.field_name();
-            let builder_output = builder.into_output(None);
+        for (config_field_name, builder) in self.config_builders {
+            let mut builder_output = builder.into_output(None);
 
             // Merge builder's value into result under the config field name
-            if let Some(config_value) = builder_output.value
-                && let Some(name) = config_field_name
-            {
-                self.result.insert(name.to_string(), config_value);
+            if let Some(config_value) = builder_output.value {
+                self.result.insert(config_field_name.clone(), config_value);
             }
 
+            if multiple_config_roots {
+                for unused_key in &mut builder_output.unused_keys {
+                    unused_key.key.insert(0, config_field_name.clone());
+                }
+            }
             unused_keys.extend(builder_output.unused_keys);
             diagnostics.extend(builder_output.diagnostics);
         }

--- a/crates/figue/src/layers/env.rs
+++ b/crates/figue/src/layers/env.rs
@@ -40,7 +40,7 @@ use std::vec::Vec;
 use facet_reflect::Span;
 use indexmap::IndexMap;
 
-use crate::config_value::{ConfigValue, ConfigValueVisitorMut};
+use crate::config_value::{ConfigValue, ConfigValueVisitorMut, Sourced};
 use crate::driver::LayerOutput;
 use crate::path::Path;
 use crate::provenance::Provenance;
@@ -207,16 +207,64 @@ impl EnvConfigBuilder {
 /// This reads env vars with the configured prefix and builds a ConfigValue tree
 /// under the schema's config field.
 pub fn parse_env(schema: &Schema, env_config: &EnvConfig, source: &dyn EnvSource) -> LayerOutput {
-    // Get the config schema - if there's no config field, we can't parse env vars
-    let Some(config_schema) = schema.config() else {
+    // Get the config schemas - if there are no config fields, we can't parse env vars
+    if schema.configs().is_empty() {
         return parse_env_no_config(env_config, source);
     };
 
+    let mut root = IndexMap::default();
+    let mut unused_keys = Vec::new();
+    let mut diagnostics = Vec::new();
+
+    for config_schema in schema.configs() {
+        let Some(field_name) = config_schema.field_name() else {
+            continue;
+        };
+
+        let mut output = parse_env_config(schema, config_schema, env_config, source);
+        if schema.configs().len() > 1 {
+            for unused_key in &mut output.unused_keys {
+                unused_key.key.insert(0, field_name.to_string());
+            }
+        }
+        unused_keys.extend(output.unused_keys);
+        diagnostics.extend(output.diagnostics);
+
+        if let Some(value) = output.value {
+            root.insert(field_name.to_string(), value);
+        }
+    }
+
+    let mut output = LayerOutput {
+        value: Some(ConfigValue::Object(Sourced::new(root))),
+        unused_keys,
+        diagnostics,
+        source_text: None,
+        config_file_path: None,
+    };
+
+    // Assign spans to env-sourced values and build the virtual source document
+    if let Some(ref mut value) = output.value {
+        let source_text = assign_env_spans(value);
+        if !source_text.is_empty() {
+            output.source_text = Some(source_text);
+        }
+    }
+
+    output
+}
+
+fn parse_env_config(
+    schema: &Schema,
+    config_schema: &ConfigStructSchema,
+    env_config: &EnvConfig,
+    source: &dyn EnvSource,
+) -> LayerOutput {
     // Use explicit prefix from config, or fall back to schema's env_prefix
-    let prefix = if env_config.prefix.is_empty() {
-        config_schema.env_prefix().unwrap_or("")
-    } else {
-        &env_config.prefix
+    let schema_prefix = config_schema.env_prefix().unwrap_or("");
+    let prefix = match (env_config.prefix.is_empty(), schema.configs().len()) {
+        (false, 1) => env_config.prefix.as_str(),
+        _ => schema_prefix,
     };
 
     let prefix_with_sep = format!("{}__", prefix);
@@ -279,17 +327,7 @@ pub fn parse_env(schema: &Schema, env_config: &EnvConfig, source: &dyn EnvSource
     // Second pass: check env aliases (lower priority than prefixed vars)
     check_env_aliases(&mut builder, config_schema, source, &[], &prefixed_paths);
 
-    let mut output = builder.into_output(config_schema.field_name());
-
-    // Assign spans to env-sourced values and build the virtual source document
-    if let Some(ref mut value) = output.value {
-        let source_text = assign_env_spans(value);
-        if !source_text.is_empty() {
-            output.source_text = Some(source_text);
-        }
-    }
-
-    output
+    builder.into_output(None)
 }
 
 /// Recursively check env aliases for all fields in a config struct.

--- a/crates/figue/src/layers/file.rs
+++ b/crates/figue/src/layers/file.rs
@@ -29,11 +29,12 @@ use std::sync::Arc;
 use std::vec::Vec;
 
 use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
 
 use crate::config_format::{ConfigFormat, ConfigFormatError, JsonFormat};
-use crate::config_value::ConfigValue;
+use crate::config_value::{ConfigValue, Sourced};
 use crate::driver::{Diagnostic, LayerOutput, Severity};
-use crate::provenance::{ConfigFile, FilePathStatus, FileResolution};
+use crate::provenance::{ConfigFile, FilePathStatus, FileResolution, Provenance};
 use crate::schema::Schema;
 use crate::value_builder::ValueBuilder;
 
@@ -333,27 +334,32 @@ impl<'a> FileParseContext<'a> {
     }
 
     fn into_result(self) -> FileParseResult {
-        // If we have a config schema and a parsed value, use ValueBuilder
+        // If we have config schemas and a parsed value, use ValueBuilder
         // to validate and collect unused keys
-        let output = if let Some(config_schema) = self.schema.config() {
+        let output = if !self.schema.configs().is_empty() {
             if let Some(ref parsed) = self.value {
-                // Create a ValueBuilder and import the parsed tree
-                let mut builder = ValueBuilder::new(config_schema);
-                builder.import_tree(parsed);
+                if self.schema.configs().len() == 1 {
+                    let config_schema = &self.schema.configs()[0];
+                    // Create a ValueBuilder and import the parsed tree
+                    let mut builder = ValueBuilder::new(config_schema);
+                    builder.import_tree(parsed);
 
-                // Unknown keys are tracked in unused_keys by the builder.
-                // In strict mode, they'll be reported by the driver alongside the config dump.
+                    // Unknown keys are tracked in unused_keys by the builder.
+                    // In strict mode, they'll be reported by the driver alongside the config dump.
 
-                // Get the output from the builder
-                let mut output =
-                    builder.into_output_with_value(self.value.clone(), config_schema.field_name());
+                    // Get the output from the builder
+                    let mut output = builder
+                        .into_output_with_value(self.value.clone(), config_schema.field_name());
 
-                // Prepend any early diagnostics (file read errors, etc.)
-                let mut all_diagnostics = self.early_diagnostics;
-                all_diagnostics.append(&mut output.diagnostics);
-                output.diagnostics = all_diagnostics;
+                    // Prepend any early diagnostics (file read errors, etc.)
+                    let mut all_diagnostics = self.early_diagnostics;
+                    all_diagnostics.append(&mut output.diagnostics);
+                    output.diagnostics = all_diagnostics;
 
-                output
+                    output
+                } else {
+                    Self::multi_config_output(self.schema, parsed, self.early_diagnostics)
+                }
             } else {
                 // No parsed value - return early diagnostics only
                 LayerOutput {
@@ -379,6 +385,95 @@ impl<'a> FileParseContext<'a> {
             output,
             resolution: self.resolution,
         }
+    }
+
+    fn multi_config_output(
+        schema: &Schema,
+        parsed: &ConfigValue,
+        early_diagnostics: Vec<Diagnostic>,
+    ) -> LayerOutput {
+        let mut root = IndexMap::default();
+        let mut unused_keys = Vec::new();
+        let mut diagnostics = early_diagnostics;
+
+        let ConfigValue::Object(parsed_obj) = parsed else {
+            diagnostics.push(Diagnostic {
+                message: "config file with multiple config roots must be an object".to_string(),
+                label: None,
+                path: None,
+                span: None,
+                severity: Severity::Error,
+            });
+
+            return LayerOutput {
+                value: None,
+                unused_keys,
+                diagnostics,
+                source_text: None,
+                config_file_path: None,
+            };
+        };
+
+        for (key, value) in &parsed_obj.value {
+            let known_root = schema
+                .configs()
+                .iter()
+                .any(|config_schema| config_schema.field_name() == Some(key.as_str()));
+            if !known_root {
+                unused_keys.push(crate::driver::UnusedKey {
+                    key: vec![key.clone()],
+                    provenance: get_provenance(value)
+                        .cloned()
+                        .unwrap_or(Provenance::Default),
+                });
+            }
+        }
+
+        for config_schema in schema.configs() {
+            let Some(field_name) = config_schema.field_name() else {
+                continue;
+            };
+
+            let Some(config_value) = parsed_obj.value.get(field_name) else {
+                continue;
+            };
+
+            let mut builder = ValueBuilder::new(config_schema);
+            builder.import_tree(config_value);
+            let mut builder_output =
+                builder.into_output_with_value(Some(config_value.clone()), None);
+
+            if let Some(value) = builder_output.value {
+                root.insert(field_name.to_string(), value);
+            }
+
+            for unused_key in &mut builder_output.unused_keys {
+                unused_key.key.insert(0, field_name.to_string());
+            }
+            unused_keys.extend(builder_output.unused_keys);
+            diagnostics.extend(builder_output.diagnostics);
+        }
+
+        LayerOutput {
+            value: Some(ConfigValue::Object(Sourced::new(root))),
+            unused_keys,
+            diagnostics,
+            source_text: None,
+            config_file_path: None,
+        }
+    }
+}
+
+fn get_provenance(value: &ConfigValue) -> Option<&Provenance> {
+    match value {
+        ConfigValue::Null(s) => s.provenance.as_ref(),
+        ConfigValue::Bool(s) => s.provenance.as_ref(),
+        ConfigValue::Integer(s) => s.provenance.as_ref(),
+        ConfigValue::Float(s) => s.provenance.as_ref(),
+        ConfigValue::String(s) => s.provenance.as_ref(),
+        ConfigValue::Array(s) => s.provenance.as_ref(),
+        ConfigValue::Object(s) => s.provenance.as_ref(),
+        ConfigValue::Enum(s) => s.provenance.as_ref(),
     }
 }
 

--- a/crates/figue/src/missing.rs
+++ b/crates/figue/src/missing.rs
@@ -44,6 +44,7 @@ pub enum MissingFieldKind {
 
 /// A available subcommand name and its doc summary.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct AvailableSubcommand {
     /// CLI name (kebab-case)
     pub name: String,
@@ -176,8 +177,8 @@ pub fn collect_missing_fields(
     // Check CLI args (top-level arguments like --verbose, --output, etc.)
     collect_missing_in_arg_level(obj_map, schema.args(), "", missing);
 
-    // Check config section if present
-    if let Some(config_schema) = schema.config() {
+    // Check config sections if present
+    for config_schema in schema.configs() {
         let env_prefix = config_schema.env_prefix();
 
         // The config value is nested under the config field name

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -74,8 +74,8 @@ pub struct Schema {
     /// Top-level arguments: `--verbose`, etc.
     args: ArgLevelSchema,
 
-    /// Optional config, read from config file, environment
-    config: Option<ConfigStructSchema>,
+    /// All config roots, read from config file, environment.
+    configs: Vec<ConfigStructSchema>,
 
     /// Special fields that trigger early exit behavior.
     special: SpecialFields,
@@ -127,6 +127,9 @@ pub struct ArgLevelSchema {
 #[derive(Facet, Debug, Clone)]
 #[facet(skip_all_unless_truthy)]
 pub struct ConfigStructSchema {
+    /// Doc comments for the config root field, if this is a root config.
+    docs: Docs,
+
     /// Name of the field in the parent struct (e.g., "config" for `#[facet(args::config)] config: ServerConfig`).
     /// None for nested structs within config.
     field_name: Option<String>,
@@ -406,8 +409,8 @@ impl Schema {
 
         self.args.visit(visitor, &mut path);
 
-        if let Some(config) = &self.config {
-            path.push("config".to_string());
+        for config in &self.configs {
+            path.push(config.field_name().unwrap_or("config").to_string());
             config.visit(visitor, &mut path);
             path.pop();
         }
@@ -527,9 +530,9 @@ impl Schema {
         &self.args
     }
 
-    /// Get the config struct schema, if any.
-    pub fn config(&self) -> Option<&ConfigStructSchema> {
-        self.config.as_ref()
+    /// Get all config struct schemas.
+    pub fn configs(&self) -> &[ConfigStructSchema] {
+        &self.configs
     }
 
     /// Get the special fields (help, version, completions) if detected.
@@ -679,6 +682,11 @@ impl Subcommand {
 }
 
 impl ConfigStructSchema {
+    /// Get documentation for this config struct.
+    pub fn docs(&self) -> &Docs {
+        &self.docs
+    }
+
     /// Get the field name in the parent struct (e.g., "config").
     pub fn field_name(&self) -> Option<&str> {
         self.field_name.as_deref()
@@ -779,6 +787,27 @@ impl ConfigEnumVariantSchema {
     /// Get the documentation for this variant.
     pub fn docs(&self) -> &Docs {
         &self.docs
+    }
+}
+
+impl ConfigValueSchema {
+    /// Unwrap [Option] wrappers if present, returning the inner schema.
+    pub fn inner_if_option(&self) -> &ConfigValueSchema {
+        match self {
+            ConfigValueSchema::Option { value, .. } => value.inner_if_option(),
+            other => other,
+        }
+    }
+
+    /// Get the type identifier for display purposes.
+    pub fn type_identifier(&self) -> &'static str {
+        match self {
+            ConfigValueSchema::Struct(s) => s.shape().type_identifier,
+            ConfigValueSchema::Vec(v) => v.element().type_identifier(),
+            ConfigValueSchema::Option { value, .. } => value.type_identifier(),
+            ConfigValueSchema::Enum(e) => e.shape().type_identifier,
+            ConfigValueSchema::Leaf(leaf) => leaf.shape.type_identifier,
+        }
     }
 }
 

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -30,11 +30,12 @@ impl Schema {
         };
 
         let ctx_root = SchemaErrorContext::root(shape);
-        let config_field = discover_config_field(struct_type.fields, &ctx_root, false)?;
+        let config_fields = discover_config_fields(struct_type.fields, &ctx_root, false)?;
 
         let (args, special) = arg_level_from_fields_with_special(struct_type.fields, &ctx_root)?;
 
-        let config = if let Some((field, field_ctx)) = config_field {
+        let mut configs = Vec::new();
+        for (field, field_ctx) in config_fields {
             let shape = field.shape();
             let config_shape = match shape.def {
                 Def::Option(opt) => opt.t,
@@ -42,23 +43,21 @@ impl Schema {
             };
             // Extract env_prefix from the config field's attributes
             let env_prefix = extract_env_prefix(field);
-            Some(config_struct_schema_from_shape(
+            configs.push(config_struct_schema_from_shape(
                 config_shape,
                 &field_ctx,
+                docs_from_lines(field.doc),
                 Some(field.effective_name().to_string()),
                 env_prefix,
-            )?)
-        } else {
-            None
-        };
-
+            )?);
+        }
         // Extract docs from the top-level shape
         let docs = docs_from_lines(shape.doc);
 
         Ok(Schema {
             docs,
             args,
-            config,
+            configs,
             special,
         })
     }
@@ -86,12 +85,12 @@ fn extract_env_prefix(field: &Field) -> Option<String> {
     }
 }
 
-fn discover_config_field(
+fn discover_config_fields(
     fields: &'static [Field],
     ctx: &SchemaErrorContext,
     inside_subcommand: bool,
-) -> Result<Option<(&'static Field, SchemaErrorContext)>, SchemaError> {
-    let mut config_field: Option<(&'static Field, SchemaErrorContext)> = None;
+) -> Result<Vec<(&'static Field, SchemaErrorContext)>, SchemaError> {
+    let mut config_fields = Vec::new();
 
     for field in fields {
         let field_ctx = ctx.with_field(field.name);
@@ -105,16 +104,7 @@ fn discover_config_field(
                 .with_primary_label("place this config field on the outermost args struct"));
             }
 
-            if let Some((_, first_ctx)) = &config_field {
-                return Err(SchemaError::new(
-                    first_ctx.clone(),
-                    "only one field may be marked with #[facet(args::config)]",
-                )
-                .with_primary_label("first marked here")
-                .with_label(field_ctx, "also marked here"));
-            }
-
-            config_field = Some((field, field_ctx));
+            config_fields.push((field, field_ctx));
             continue;
         }
 
@@ -137,19 +127,11 @@ fn discover_config_field(
                 ));
             };
 
-            if let Some((inner_field, inner_ctx)) =
-                discover_config_field(struct_type.fields, &field_ctx, inside_subcommand)?
-            {
-                if let Some((_, first_ctx)) = &config_field {
-                    return Err(SchemaError::new(
-                        first_ctx.clone(),
-                        "only one field may be marked with #[facet(args::config)]",
-                    )
-                    .with_primary_label("first marked here")
-                    .with_label(inner_ctx, "also marked here"));
-                }
-                config_field = Some((inner_field, inner_ctx));
-            }
+            config_fields.extend(discover_config_fields(
+                struct_type.fields,
+                &field_ctx,
+                inside_subcommand,
+            )?);
         }
 
         if field.has_attr(Some("args"), "subcommand") {
@@ -169,12 +151,12 @@ fn discover_config_field(
                 let variant_ctx =
                     SchemaErrorContext::root(enum_shape).with_variant(variant_cli_name(variant));
                 let variant_fields = variant_fields_for_schema(variant);
-                discover_config_field(variant_fields, &variant_ctx, true)?;
+                discover_config_fields(variant_fields, &variant_ctx, true)?;
             }
         }
     }
 
-    Ok(config_field)
+    Ok(config_fields)
 }
 
 /// Extract all env_alias values from a field's `#[facet(args::env_alias = "...")]` attributes.
@@ -361,7 +343,7 @@ fn value_schema_from_shape(
         }),
         _ => match &shape.ty {
             Type::User(UserType::Struct(_)) => Ok(ValueSchema::Struct {
-                fields: config_struct_schema_from_shape(shape, ctx, None, None)?,
+                fields: config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None)?,
                 shape,
             }),
             _ => Ok(ValueSchema::Leaf(leaf_schema_from_shape(shape, ctx)?)),
@@ -384,7 +366,7 @@ fn config_value_schema_from_shape(
         })),
         _ => match &shape.ty {
             Type::User(UserType::Struct(_)) => Ok(ConfigValueSchema::Struct(
-                config_struct_schema_from_shape(shape, ctx, None, None)?,
+                config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None)?,
             )),
             Type::User(UserType::Enum(enum_type)) => Ok(ConfigValueSchema::Enum(
                 config_enum_schema_from_shape(shape, *enum_type, ctx)?,
@@ -442,15 +424,25 @@ fn config_enum_schema_from_shape(
 fn config_struct_schema_from_shape(
     shape: &'static Shape,
     ctx: &SchemaErrorContext,
+    docs: Docs,
     field_name: Option<String>,
     env_prefix: Option<String>,
 ) -> Result<ConfigStructSchema, SchemaError> {
-    config_struct_schema_from_shape_inner(shape, ctx, field_name, env_prefix, Vec::new(), false)
+    config_struct_schema_from_shape_inner(
+        shape,
+        ctx,
+        docs,
+        field_name,
+        env_prefix,
+        Vec::new(),
+        false,
+    )
 }
 
 fn config_struct_schema_from_shape_inner(
     shape: &'static Shape,
     ctx: &SchemaErrorContext,
+    docs: Docs,
     field_name: Option<String>,
     env_prefix: Option<String>,
     path_prefix: Vec<String>,
@@ -501,6 +493,7 @@ fn config_struct_schema_from_shape_inner(
             let inner = config_struct_schema_from_shape_inner(
                 inner_shape,
                 &field_ctx,
+                Docs::default(),
                 None,
                 None,
                 new_prefix,
@@ -556,6 +549,7 @@ fn config_struct_schema_from_shape_inner(
     check_env_alias_conflicts(&fields_map, ctx)?;
 
     Ok(ConfigStructSchema {
+        docs,
         field_name,
         env_prefix,
         shape,

--- a/crates/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_basic.snap
+++ b/crates/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_basic.snap
@@ -129,31 +129,36 @@ expression: "facet_json :: to_string_pretty(& value).unwrap()"
     "subcommand_field_name": "command",
     "subcommand_optional": true
   },
-  "config": {
-    "field_name": "config",
-    "env_prefix": "APP",
-    "fields": {
-      "host": {
-        "docs": {},
-        "value": {
-          "Leaf": {
-            "kind": {
-              "Scalar": "String"
+  "configs": [
+    {
+      "docs": {
+        "summary": "Config"
+      },
+      "field_name": "config",
+      "env_prefix": "APP",
+      "fields": {
+        "host": {
+          "docs": {},
+          "value": {
+            "Leaf": {
+              "kind": {
+                "Scalar": "String"
+              }
             }
           }
-        }
-      },
-      "port": {
-        "docs": {},
-        "value": {
-          "Leaf": {
-            "kind": {
-              "Scalar": "Integer"
+        },
+        "port": {
+          "docs": {},
+          "value": {
+            "Leaf": {
+              "kind": {
+                "Scalar": "Integer"
+              }
             }
           }
         }
       }
     }
-  },
+  ],
   "special": {}
 }

--- a/crates/figue/src/schema/tests.rs
+++ b/crates/figue/src/schema/tests.rs
@@ -390,7 +390,7 @@ struct ArgsWithFlattenedConfig {
 #[test]
 fn test_config_flatten_schema_builds() {
     let schema = Schema::from_shape(ArgsWithFlattenedConfig::SHAPE).expect("schema should build");
-    let config = schema.config().expect("should have config");
+    let config = schema.configs().first().expect("should have config");
     let fields = config.fields();
 
     // Should have 3 fields: name, log_level, debug (flattened from common)
@@ -434,7 +434,7 @@ struct ArgsWithNestedFlattenConfig {
 fn test_config_nested_flatten_schema_builds() {
     let schema =
         Schema::from_shape(ArgsWithNestedFlattenConfig::SHAPE).expect("schema should build");
-    let config = schema.config().expect("should have config");
+    let config = schema.configs().first().expect("should have config");
     let fields = config.fields();
 
     // Should have 5 fields: app_name + log_level, debug (from common) + host, port (from database)

--- a/crates/figue/src/value_builder.rs
+++ b/crates/figue/src/value_builder.rs
@@ -749,7 +749,7 @@ mod tests {
     #[test]
     fn test_simple_set() {
         let schema = Schema::from_shape(ArgsWithSimpleConfig::SHAPE).unwrap();
-        let config_schema = schema.config().unwrap();
+        let config_schema = schema.configs().first().unwrap();
         let mut builder = ValueBuilder::new(config_schema);
 
         let success = builder.set(
@@ -768,7 +768,7 @@ mod tests {
     #[test]
     fn test_invalid_path() {
         let schema = Schema::from_shape(ArgsWithSimpleConfig::SHAPE).unwrap();
-        let config_schema = schema.config().unwrap();
+        let config_schema = schema.configs().first().unwrap();
         let mut builder = ValueBuilder::new(config_schema);
 
         let success = builder.set(
@@ -784,7 +784,7 @@ mod tests {
     #[test]
     fn test_enum_variant_path() {
         let schema = Schema::from_shape(ArgsWithEnumConfig::SHAPE).unwrap();
-        let config_schema = schema.config().unwrap();
+        let config_schema = schema.configs().first().unwrap();
         let mut builder = ValueBuilder::new(config_schema);
 
         let prov_bucket = Provenance::env("TEST__STORAGE__S3__BUCKET", "my-bucket");
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     fn test_enum_variant_conflict() {
         let schema = Schema::from_shape(ArgsWithEnumConfig::SHAPE).unwrap();
-        let config_schema = schema.config().unwrap();
+        let config_schema = schema.configs().first().unwrap();
         let mut builder = ValueBuilder::new(config_schema);
 
         // Set S3 variant
@@ -841,7 +841,7 @@ mod tests {
     #[test]
     fn test_has_value_at() {
         let schema = Schema::from_shape(ArgsWithSimpleConfig::SHAPE).unwrap();
-        let config_schema = schema.config().unwrap();
+        let config_schema = schema.configs().first().unwrap();
         let mut builder = ValueBuilder::new(config_schema);
 
         assert!(!builder.has_value_at(&path(&["port"])));

--- a/crates/figue/tests/integration/layered.rs
+++ b/crates/figue/tests/integration/layered.rs
@@ -192,6 +192,76 @@ fn test_layered_cli_overrides_all() {
     );
 }
 
+#[derive(Facet, Debug)]
+struct MultiConfigArgs {
+    #[facet(args::config, args::env_prefix = "BEE", rename = "cfg")]
+    cfg: PrimaryConfig,
+
+    #[facet(args::config, args::env_prefix = "BEE_EVAL", rename = "eval")]
+    eval: EvalConfig,
+
+    #[facet(args::subcommand)]
+    command: MultiConfigCommand,
+}
+
+#[derive(Facet, Debug)]
+struct PrimaryConfig {
+    #[facet(default = "localhost")]
+    host: String,
+
+    #[facet(default = 8080)]
+    port: u16,
+}
+
+#[derive(Facet, Debug)]
+struct EvalConfig {
+    dataset: String,
+
+    #[facet(default = 10)]
+    samples: u32,
+
+    #[facet(default)]
+    enabled: bool,
+}
+
+#[derive(Facet, Debug)]
+#[repr(u8)]
+enum MultiConfigCommand {
+    Run,
+}
+
+#[test]
+fn test_layered_multiple_config_roots() {
+    let config_json = r#"{
+        "cfg": {
+            "host": "file-host",
+            "port": 3000
+        },
+        "eval": {
+            "dataset": "file-dataset",
+            "samples": 20
+        }
+    }"#;
+
+    let env = MockEnv::from_pairs([("BEE__PORT", "4000"), ("BEE_EVAL__SAMPLES", "30")]);
+
+    let config = builder::<MultiConfigArgs>()
+        .unwrap()
+        .cli(|cli| cli.args(["--cfg.host", "cli-host", "--eval.enabled", "true", "run"]))
+        .env(|e| e.source(env))
+        .file(|f| f.content(config_json, "config.json"))
+        .build();
+
+    let args = Driver::new(config).run().unwrap();
+
+    assert_eq!(args.cfg.host, "cli-host");
+    assert_eq!(args.cfg.port, 4000);
+    assert_eq!(args.eval.dataset, "file-dataset");
+    assert_eq!(args.eval.samples, 30);
+    assert!(args.eval.enabled);
+    assert!(matches!(args.command, MultiConfigCommand::Run));
+}
+
 /// Simpler structure for testing dump output with all sources visible.
 #[derive(Facet, Debug)]
 struct SimpleArgs {


### PR DESCRIPTION
Summary:
- Adds schema and layer support for multiple top-level #[facet(args::config)] roots, including CLI dotted overrides, env prefixes, config files, defaults, missing-field checks, enum conflict checks, dumps, and unknown-key reporting.
- Shows config roots in help output, including --cfg <FILE> and --cfg.<KEY> <VALUE> forms.

Testing:
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo nextest run -E 'package(figue)' --no-fail-fast\n- Pre-push hook passed: clippy, docs, build tests, run tests