### PR TITLE
Add built-in JSON Schema export

### DIFF
--- a/crates/figue-attrs/src/lib.rs
+++ b/crates/figue-attrs/src/lib.rs
@@ -161,6 +161,14 @@ facet::define_attr_grammar! {
         ///
         /// Usage: `#[facet(figue::completions)]`
         Completions,
+        /// Marks a field as the JSON Schema export flag.
+        ///
+        /// When this flag is set, the driver writes one JSON Schema file per config root
+        /// to the requested output directory and exits with code 0.
+        /// The field should be `Option<String>`.
+        ///
+        /// Usage: `#[facet(figue::export_jsonschemas)]`
+        ExportJsonschemas,
         /// Specifies the origin path for field extraction.
         ///
         /// Used in "requirements structs" to indicate which field from the

--- a/crates/figue/src/builder.rs
+++ b/crates/figue/src/builder.rs
@@ -54,6 +54,7 @@
 #![allow(private_interfaces)]
 
 use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
 use std::string::String;
 
 use camino::Utf8PathBuf;
@@ -63,6 +64,9 @@ use facet_reflect::ReflectError;
 use crate::{
     config_format::{ConfigFormat, ConfigFormatError},
     help::HelpConfig,
+    json_schema::{
+        JsonSchemaError, JsonSchemaFile, generate_json_schemas_for_schema, write_json_schema_files,
+    },
     layers::{
         cli::{CliConfig, CliConfigBuilder},
         env::{EnvConfig, EnvConfigBuilder},
@@ -390,6 +394,34 @@ impl<T> ConfigBuilder<T> {
             file_config: self.file_config,
             _phantom: PhantomData,
         }
+    }
+
+    /// Generate one JSON Schema document per config root.
+    pub fn generate_json_schemas(&self) -> Vec<JsonSchemaFile> {
+        generate_json_schemas_for_schema(&self.schema)
+    }
+
+    /// Write one JSON Schema file per config root to `output_dir`.
+    pub fn write_json_schemas(
+        &self,
+        output_dir: impl AsRef<Path>,
+    ) -> Result<Vec<PathBuf>, JsonSchemaError> {
+        write_json_schema_files(output_dir, &self.generate_json_schemas())
+    }
+}
+
+impl<T> Config<T> {
+    /// Generate one JSON Schema document per config root.
+    pub fn generate_json_schemas(&self) -> Vec<JsonSchemaFile> {
+        generate_json_schemas_for_schema(&self.schema)
+    }
+
+    /// Write one JSON Schema file per config root to `output_dir`.
+    pub fn write_json_schemas(
+        &self,
+        output_dir: impl AsRef<Path>,
+    ) -> Result<Vec<PathBuf>, JsonSchemaError> {
+        write_json_schema_files(output_dir, &self.generate_json_schemas())
     }
 }
 

--- a/crates/figue/src/driver.rs
+++ b/crates/figue/src/driver.rs
@@ -19,6 +19,7 @@
 #![allow(clippy::result_large_err)]
 
 use std::marker::PhantomData;
+use std::path::PathBuf;
 use std::string::String;
 use std::vec::Vec;
 
@@ -31,6 +32,7 @@ use crate::dump::dump_config_with_schema;
 use crate::enum_conflicts::detect_enum_conflicts;
 use crate::env_subst::{EnvSubstError, RealEnv, substitute_env_vars};
 use crate::help::generate_help_for_subcommand_with_config_formats;
+use crate::json_schema::{JsonSchemaError, write_json_schema_files};
 use crate::layers::{cli::parse_cli, env::parse_env, file::parse_file};
 use crate::merge::merge_layers;
 use crate::missing::{
@@ -273,6 +275,36 @@ impl<T: Facet<'static>> Driver<T> {
                     .unwrap_or_else(|| "program".to_string());
                 let text = format!("{} {}", program_name, version);
                 return DriverOutcome::err(DriverError::Version { text });
+            }
+
+            // Check for --export-jsonschemas <dir>
+            if let Some(ref export_jsonschemas_path) = special.export_jsonschemas
+                && let Some(value) = cli_value.get_by_path(export_jsonschemas_path)
+            {
+                match extract_string_from_value(value) {
+                    Some(output_dir) => {
+                        let files = self.config.generate_json_schemas();
+                        match write_json_schema_files(&output_dir, &files) {
+                            Ok(paths) => {
+                                return DriverOutcome::err(DriverError::JsonSchemasExported {
+                                    paths,
+                                });
+                            }
+                            Err(error) => {
+                                return DriverOutcome::err(DriverError::JsonSchemaExport { error });
+                            }
+                        }
+                    }
+                    None => {
+                        all_diagnostics.push(Diagnostic {
+                            message: "export-jsonschemas requires an output directory".to_string(),
+                            label: None,
+                            path: None,
+                            span: None,
+                            severity: Severity::Error,
+                        });
+                    }
+                }
             }
 
             // Check for --completions <shell>
@@ -869,6 +901,7 @@ impl<T> DriverOutcome<T> {
     /// | `--help` passed | Prints help to stdout, exits with code 0 |
     /// | `--version` passed | Prints version to stdout, exits with code 0 |
     /// | `--completions` passed | Prints shell script to stdout, exits with code 0 |
+    /// | `--export-jsonschemas` passed | Writes schemas, prints paths to stdout, exits with code 0 |
     /// | Parse failed | Prints diagnostics to stderr, exits with code 1 |
     ///
     /// # Example
@@ -910,11 +943,22 @@ impl<T> DriverOutcome<T> {
                 println!("{}", text);
                 std::process::exit(0);
             }
+            Err(DriverError::JsonSchemasExported { paths }) => {
+                println!("Wrote JSON Schema files:");
+                for path in paths {
+                    println!("{}", path.display());
+                }
+                std::process::exit(0);
+            }
             Err(DriverError::Failed { report }) => {
                 eprintln!("{}", report.render_pretty());
                 std::process::exit(1);
             }
             Err(DriverError::Builder { error }) => {
+                eprintln!("{}", error);
+                std::process::exit(1);
+            }
+            Err(DriverError::JsonSchemaExport { error }) => {
                 eprintln!("{}", error);
                 std::process::exit(1);
             }
@@ -1247,6 +1291,13 @@ fn extract_shell_from_value(value: &ConfigValue) -> Option<Shell> {
     }
 }
 
+fn extract_string_from_value(value: &ConfigValue) -> Option<String> {
+    match value {
+        ConfigValue::String(s) => Some(s.value.clone()),
+        _ => None,
+    }
+}
+
 /// Returns true when the completions value is the "auto" sentinel inserted by
 /// the CLI parser for `--completions` with no explicit argument.
 fn is_auto_detect_sentinel(value: &ConfigValue) -> bool {
@@ -1258,9 +1309,9 @@ fn is_auto_detect_sentinel(value: &ConfigValue) -> bool {
 /// This enum covers two distinct cases:
 ///
 /// - **Early exits** ([`Help`](Self::Help), [`Version`](Self::Version),
-///   [`Completions`](Self::Completions)) — the user asked for something other than
-///   running the program. These have exit code 0 and are "errors" only in the sense
-///   that no `T` was produced.
+///   [`Completions`](Self::Completions), [`JsonSchemasExported`](Self::JsonSchemasExported)) —
+///   the user asked for something other than running the program. These have exit code 0
+///   and are "errors" only in the sense that no `T` was produced.
 ///
 /// - **Actual errors** ([`Failed`](Self::Failed), [`Builder`](Self::Builder),
 ///   [`EnvSubst`](Self::EnvSubst)) — something went wrong. These have exit code 1.
@@ -1277,8 +1328,10 @@ fn is_auto_detect_sentinel(value: &ConfigValue) -> bool {
 /// | `Help` | 0 | Early exit |
 /// | `Version` | 0 | Early exit |
 /// | `Completions` | 0 | Early exit |
+/// | `JsonSchemasExported` | 0 | Early exit |
 /// | `Failed` | 1 | Error |
 /// | `Builder` | 1 | Error |
+/// | `JsonSchemaExport` | 1 | Error |
 /// | `EnvSubst` | 1 | Error |
 ///
 /// # Example
@@ -1375,6 +1428,24 @@ pub enum DriverError {
         text: String,
     },
 
+    /// JSON Schema files were exported.
+    ///
+    /// Exit code: 0
+    ///
+    /// This is a "successful" exit - the user asked for schemas and got them.
+    JsonSchemasExported {
+        /// Paths that were written.
+        paths: Vec<PathBuf>,
+    },
+
+    /// JSON Schema export failed.
+    ///
+    /// Exit code: 1
+    JsonSchemaExport {
+        /// Export error.
+        error: JsonSchemaError,
+    },
+
     /// Environment variable substitution failed.
     ///
     /// Exit code: 1
@@ -1396,6 +1467,8 @@ impl DriverError {
             DriverError::Help { .. } => 0,
             DriverError::Completions { .. } => 0,
             DriverError::Version { .. } => 0,
+            DriverError::JsonSchemasExported { .. } => 0,
+            DriverError::JsonSchemaExport { .. } => 1,
             DriverError::EnvSubst { .. } => 1,
         }
     }
@@ -1433,6 +1506,14 @@ impl std::fmt::Display for DriverError {
             }
             DriverError::Completions { script } => write!(f, "{}", script),
             DriverError::Version { text } => write!(f, "{}", text),
+            DriverError::JsonSchemasExported { paths } => {
+                writeln!(f, "Wrote JSON Schema files:")?;
+                for path in paths {
+                    writeln!(f, "{}", path.display())?;
+                }
+                Ok(())
+            }
+            DriverError::JsonSchemaExport { error } => write!(f, "{}", error),
             DriverError::EnvSubst { error } => write!(f, "{}", error),
         }
     }
@@ -1462,10 +1543,19 @@ impl std::process::Termination for DriverError {
             DriverError::Completions { script } => {
                 println!("{}", script);
             }
+            DriverError::JsonSchemasExported { paths } => {
+                println!("Wrote JSON Schema files:");
+                for path in paths {
+                    println!("{}", path.display());
+                }
+            }
             DriverError::Failed { report } => {
                 eprintln!("{}", report.render_pretty());
             }
             DriverError::Builder { error } => {
+                eprintln!("{}", error);
+            }
+            DriverError::JsonSchemaExport { error } => {
                 eprintln!("{}", error);
             }
             DriverError::EnvSubst { error } => {
@@ -1692,6 +1782,27 @@ mod tests {
                 );
             }
             other => panic!("expected DriverError::Completions, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_driver_export_jsonschemas() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let arg = format!("--export-jsonschemas={}", tempdir.path().display());
+        let config = builder::<ArgsWithConfigAndBuiltins>()
+            .unwrap()
+            .cli(|cli| cli.args([arg]))
+            .build();
+
+        let driver = Driver::new(config);
+        let result = driver.run().into_result();
+
+        match result {
+            Err(DriverError::JsonSchemasExported { paths }) => {
+                assert_eq!(paths.len(), 1);
+                assert!(tempdir.path().join("config.schema.json").exists());
+            }
+            other => panic!("expected DriverError::JsonSchemasExported, got {:?}", other),
         }
     }
 

--- a/crates/figue/src/json_schema.rs
+++ b/crates/figue/src/json_schema.rs
@@ -1,0 +1,484 @@
+//! JSON Schema export for figue config roots.
+
+use std::fmt;
+use std::fs;
+use std::path::{Path as FsPath, PathBuf};
+use std::string::String;
+use std::vec::Vec;
+
+use facet::Facet;
+
+use crate::config_value::ConfigValue;
+use crate::schema::{
+    ConfigEnumSchema, ConfigEnumVariantSchema, ConfigFieldSchema, ConfigStructSchema,
+    ConfigValueSchema, Docs, LeafKind, ScalarType, Schema, error::SchemaError,
+};
+
+/// One generated JSON Schema document and the file name it should be written to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsonSchemaFile {
+    /// File name, derived from the config root name, for example `cfg.schema.json`.
+    pub file_name: String,
+    /// Pretty-printed JSON Schema contents.
+    pub contents: String,
+}
+
+/// Error returned while generating or writing JSON Schema files.
+#[derive(Debug)]
+pub enum JsonSchemaError {
+    /// The figue schema could not be built from the target type.
+    Schema(SchemaError),
+    /// A filesystem operation failed while writing schemas.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for JsonSchemaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JsonSchemaError::Schema(err) => write!(f, "{err}"),
+            JsonSchemaError::Io(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for JsonSchemaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            JsonSchemaError::Schema(err) => Some(err),
+            JsonSchemaError::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<SchemaError> for JsonSchemaError {
+    fn from(value: SchemaError) -> Self {
+        Self::Schema(value)
+    }
+}
+
+impl From<std::io::Error> for JsonSchemaError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// Generate one JSON Schema document per config root in `T`.
+///
+/// File names are derived from effective config root names:
+/// `cfg` becomes `cfg.schema.json`.
+pub fn generate_json_schemas<T>() -> Result<Vec<JsonSchemaFile>, JsonSchemaError>
+where
+    T: Facet<'static>,
+{
+    let schema = Schema::from_shape(T::SHAPE)?;
+    Ok(generate_json_schemas_for_schema(&schema))
+}
+
+/// Write one JSON Schema file per config root in `T` to `output_dir`.
+///
+/// The output directory is created if it does not already exist. The returned
+/// paths are the files that were written.
+pub fn write_json_schemas<T>(
+    output_dir: impl AsRef<FsPath>,
+) -> Result<Vec<PathBuf>, JsonSchemaError>
+where
+    T: Facet<'static>,
+{
+    let files = generate_json_schemas::<T>()?;
+    write_json_schema_files(output_dir, &files)
+}
+
+pub(crate) fn generate_json_schemas_for_schema(schema: &Schema) -> Vec<JsonSchemaFile> {
+    schema
+        .configs()
+        .iter()
+        .map(|config| {
+            let root_name = config.field_name().unwrap_or("config");
+            let json = config_root_schema(config);
+            JsonSchemaFile {
+                file_name: format!("{}.schema.json", sanitize_file_stem(root_name)),
+                contents: json.to_pretty_string(),
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn write_json_schema_files(
+    output_dir: impl AsRef<FsPath>,
+    files: &[JsonSchemaFile],
+) -> Result<Vec<PathBuf>, JsonSchemaError> {
+    let output_dir = output_dir.as_ref();
+    fs::create_dir_all(output_dir)?;
+
+    let mut written = Vec::with_capacity(files.len());
+    for file in files {
+        let path = output_dir.join(&file.file_name);
+        fs::write(&path, &file.contents)?;
+        written.push(path);
+    }
+
+    Ok(written)
+}
+
+fn config_root_schema(config: &ConfigStructSchema) -> Json {
+    let mut object = Vec::new();
+    object.push((
+        "$schema".to_string(),
+        Json::String("https://json-schema.org/draft/2020-12/schema".to_string()),
+    ));
+    object.push((
+        "title".to_string(),
+        Json::String(config.shape().to_string()),
+    ));
+    if let Some(description) = description(config.docs()) {
+        object.push(("description".to_string(), Json::String(description)));
+    }
+    append_struct_keywords(&mut object, config);
+    Json::Object(object)
+}
+
+fn struct_schema(config: &ConfigStructSchema) -> Json {
+    let mut object = Vec::new();
+    append_struct_keywords(&mut object, config);
+    Json::Object(object)
+}
+
+fn append_struct_keywords(object: &mut Vec<(String, Json)>, config: &ConfigStructSchema) {
+    object.push(("type".to_string(), Json::String("object".to_string())));
+    object.push(("additionalProperties".to_string(), Json::Bool(false)));
+
+    let mut properties = Vec::new();
+    let mut required = Vec::new();
+
+    for (field_name, field) in config.fields() {
+        properties.push((field_name.clone(), field_schema(field)));
+        if is_required_field(field) {
+            required.push(Json::String(field_name.clone()));
+        }
+    }
+
+    object.push(("properties".to_string(), Json::Object(properties)));
+    if !required.is_empty() {
+        object.push(("required".to_string(), Json::Array(required)));
+    }
+}
+
+fn field_schema(field: &ConfigFieldSchema) -> Json {
+    let mut schema = value_schema(field.value());
+
+    if let Some(description) = description(field.docs()) {
+        schema.insert("description", Json::String(description));
+    }
+    if field.is_sensitive() {
+        schema.insert("writeOnly", Json::Bool(true));
+    }
+    if let Some(default) = field.default().and_then(config_value_to_json) {
+        schema.insert("default", default);
+    }
+
+    schema
+}
+
+fn value_schema(value: &ConfigValueSchema) -> Json {
+    match value {
+        ConfigValueSchema::Struct(config) => struct_schema(config),
+        ConfigValueSchema::Vec(vec) => Json::object([
+            ("type", Json::String("array".to_string())),
+            ("items", value_schema(vec.element())),
+        ]),
+        ConfigValueSchema::Option { value, .. } => Json::object([(
+            "anyOf",
+            Json::Array(vec![
+                value_schema(value),
+                Json::object([("type", Json::String("null".to_string()))]),
+            ]),
+        )]),
+        ConfigValueSchema::Enum(enum_schema) => enum_schema_json(enum_schema),
+        ConfigValueSchema::Leaf(leaf) => match leaf.kind() {
+            LeafKind::Scalar(scalar) => scalar_schema(scalar),
+            LeafKind::Enum { variants } => Json::object([
+                ("type", Json::String("string".to_string())),
+                (
+                    "enum",
+                    Json::Array(variants.iter().map(|v| Json::String(v.clone())).collect()),
+                ),
+            ]),
+        },
+    }
+}
+
+fn scalar_schema(scalar: &ScalarType) -> Json {
+    let schema_type = match scalar {
+        ScalarType::Bool => "boolean",
+        ScalarType::String | ScalarType::Other => "string",
+        ScalarType::Integer => "integer",
+        ScalarType::Float => "number",
+    };
+    Json::object([("type", Json::String(schema_type.to_string()))])
+}
+
+fn enum_schema_json(enum_schema: &ConfigEnumSchema) -> Json {
+    let all_unit = enum_schema
+        .variants()
+        .values()
+        .all(|variant| variant.fields().is_empty());
+
+    if all_unit {
+        return Json::object([
+            ("type", Json::String("string".to_string())),
+            (
+                "enum",
+                Json::Array(
+                    enum_schema
+                        .variants()
+                        .keys()
+                        .map(|name| Json::String(name.clone()))
+                        .collect(),
+                ),
+            ),
+        ]);
+    }
+
+    Json::object([(
+        "oneOf",
+        Json::Array(
+            enum_schema
+                .variants()
+                .iter()
+                .map(|(variant_name, variant)| variant_schema(variant_name, variant))
+                .collect(),
+        ),
+    )])
+}
+
+fn variant_schema(variant_name: &str, variant: &ConfigEnumVariantSchema) -> Json {
+    if variant.fields().is_empty() {
+        let mut object = vec![("const".to_string(), Json::String(variant_name.to_string()))];
+        if let Some(description) = description(variant.docs()) {
+            object.push(("description".to_string(), Json::String(description)));
+        }
+        return Json::Object(object);
+    }
+
+    let fields = ConfigStructLike { variant };
+    let variant_object = fields.to_json_schema();
+    let mut object = vec![
+        ("type".to_string(), Json::String("object".to_string())),
+        ("additionalProperties".to_string(), Json::Bool(false)),
+        (
+            "properties".to_string(),
+            Json::Object(vec![(variant_name.to_string(), variant_object)]),
+        ),
+        (
+            "required".to_string(),
+            Json::Array(vec![Json::String(variant_name.to_string())]),
+        ),
+    ];
+    if let Some(description) = description(variant.docs()) {
+        object.push(("description".to_string(), Json::String(description)));
+    }
+    Json::Object(object)
+}
+
+struct ConfigStructLike<'a> {
+    variant: &'a ConfigEnumVariantSchema,
+}
+
+impl ConfigStructLike<'_> {
+    fn to_json_schema(&self) -> Json {
+        let mut properties = Vec::new();
+        let mut required = Vec::new();
+
+        for (field_name, field) in self.variant.fields() {
+            properties.push((field_name.clone(), field_schema(field)));
+            if is_required_field(field) {
+                required.push(Json::String(field_name.clone()));
+            }
+        }
+
+        let mut object = vec![
+            ("type".to_string(), Json::String("object".to_string())),
+            ("additionalProperties".to_string(), Json::Bool(false)),
+            ("properties".to_string(), Json::Object(properties)),
+        ];
+        if !required.is_empty() {
+            object.push(("required".to_string(), Json::Array(required)));
+        }
+        Json::Object(object)
+    }
+}
+
+fn is_required_field(field: &ConfigFieldSchema) -> bool {
+    !matches!(field.value(), ConfigValueSchema::Option { .. }) && field.default().is_none()
+}
+
+fn description(docs: &Docs) -> Option<String> {
+    match (docs.summary(), docs.details()) {
+        (Some(summary), Some(details)) => Some(format!("{summary}\n\n{details}")),
+        (Some(summary), None) => Some(summary.to_string()),
+        (None, Some(details)) => Some(details.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn config_value_to_json(value: &ConfigValue) -> Option<Json> {
+    match value {
+        ConfigValue::Null(_) => Some(Json::Null),
+        ConfigValue::Bool(value) => Some(Json::Bool(value.value)),
+        ConfigValue::Integer(value) => Some(Json::Number(value.value.to_string())),
+        ConfigValue::Float(value) => Some(Json::Number(value.value.to_string())),
+        ConfigValue::String(value) => Some(Json::String(value.value.clone())),
+        ConfigValue::Array(value) => Some(Json::Array(
+            value
+                .value
+                .iter()
+                .filter_map(config_value_to_json)
+                .collect(),
+        )),
+        ConfigValue::Object(value) => Some(Json::Object(
+            value
+                .value
+                .iter()
+                .filter_map(|(key, value)| Some((key.clone(), config_value_to_json(value)?)))
+                .collect(),
+        )),
+        ConfigValue::Enum(value) => Some(Json::Object(vec![(
+            value.value.variant.clone(),
+            Json::Object(
+                value
+                    .value
+                    .fields
+                    .iter()
+                    .filter_map(|(key, value)| Some((key.clone(), config_value_to_json(value)?)))
+                    .collect(),
+            ),
+        )])),
+    }
+}
+
+fn sanitize_file_stem(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+
+    if sanitized.is_empty() {
+        "config".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Json {
+    Null,
+    Bool(bool),
+    Number(String),
+    String(String),
+    Array(Vec<Json>),
+    Object(Vec<(String, Json)>),
+}
+
+impl Json {
+    fn object<const N: usize>(entries: [(&str, Json); N]) -> Self {
+        Self::Object(
+            entries
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value))
+                .collect(),
+        )
+    }
+
+    fn insert(&mut self, key: &str, value: Json) {
+        let Self::Object(entries) = self else {
+            return;
+        };
+        entries.push((key.to_string(), value));
+    }
+
+    fn to_pretty_string(&self) -> String {
+        let mut output = String::new();
+        self.write_pretty(&mut output, 0);
+        output.push('\n');
+        output
+    }
+
+    fn write_pretty(&self, output: &mut String, indent: usize) {
+        match self {
+            Json::Null => output.push_str("null"),
+            Json::Bool(value) => output.push_str(if *value { "true" } else { "false" }),
+            Json::Number(value) => output.push_str(value),
+            Json::String(value) => write_json_string(output, value),
+            Json::Array(values) => {
+                if values.is_empty() {
+                    output.push_str("[]");
+                    return;
+                }
+
+                output.push('[');
+                output.push('\n');
+                for (index, value) in values.iter().enumerate() {
+                    write_indent(output, indent + 2);
+                    value.write_pretty(output, indent + 2);
+                    if index + 1 != values.len() {
+                        output.push(',');
+                    }
+                    output.push('\n');
+                }
+                write_indent(output, indent);
+                output.push(']');
+            }
+            Json::Object(entries) => {
+                if entries.is_empty() {
+                    output.push_str("{}");
+                    return;
+                }
+
+                output.push('{');
+                output.push('\n');
+                for (index, (key, value)) in entries.iter().enumerate() {
+                    write_indent(output, indent + 2);
+                    write_json_string(output, key);
+                    output.push_str(": ");
+                    value.write_pretty(output, indent + 2);
+                    if index + 1 != entries.len() {
+                        output.push(',');
+                    }
+                    output.push('\n');
+                }
+                write_indent(output, indent);
+                output.push('}');
+            }
+        }
+    }
+}
+
+fn write_indent(output: &mut String, indent: usize) {
+    for _ in 0..indent {
+        output.push(' ');
+    }
+}
+
+fn write_json_string(output: &mut String, value: &str) {
+    output.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            '\u{08}' => output.push_str("\\b"),
+            '\u{0c}' => output.push_str("\\f"),
+            ch if ch.is_control() => output.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => output.push(ch),
+        }
+    }
+    output.push('"');
+}

--- a/crates/figue/src/lib.rs
+++ b/crates/figue/src/lib.rs
@@ -176,6 +176,7 @@ pub(crate) mod env_subst;
 pub(crate) mod error;
 pub(crate) mod extract;
 pub(crate) mod help;
+pub(crate) mod json_schema;
 pub(crate) mod layers;
 pub(crate) mod merge;
 pub(crate) mod missing;
@@ -202,6 +203,7 @@ pub use driver::{Driver, DriverError, DriverOutcome, DriverOutput, DriverReport}
 pub use error::{ArgsErrorKind, ArgsErrorWithInput};
 pub use extract::{ExtractError, ExtractMissingField};
 pub use help::{HelpConfig, generate_help, generate_help_for_shape};
+pub use json_schema::{JsonSchemaError, JsonSchemaFile, generate_json_schemas, write_json_schemas};
 pub use layers::env::MockEnv;
 pub use layers::file::FormatRegistry;
 
@@ -330,6 +332,7 @@ pub fn from_slice<T: Facet<'static>>(args: &[&str]) -> DriverOutcome<T> {
 /// - `--help` / `-h`: Shows help and exits with code 0
 /// - `--version` / `-V`: Shows version and exits with code 0
 /// - `--completions <SHELL>`: Generates shell completions and exits with code 0
+/// - `--export-jsonschemas <DIR>`: Writes one JSON Schema file per config root and exits with code 0
 ///
 /// # Setting the Version
 ///
@@ -405,6 +408,10 @@ pub struct FigueBuiltins {
     /// Generate shell completions.
     #[facet(args::named, args::completions, default)]
     pub completions: Option<Shell>,
+
+    /// Export JSON Schema files for all config roots.
+    #[facet(args::named, args::export_jsonschemas, args::label = "DIR", default)]
+    pub export_jsonschemas: Option<String>,
 }
 
 #[cfg(test)]
@@ -478,6 +485,15 @@ mod tests {
         assert_eq!(
             special.completions.as_ref().unwrap(),
             &vec!["completions".to_string()]
+        );
+
+        assert!(
+            special.export_jsonschemas.is_some(),
+            "export_jsonschemas should be detected"
+        );
+        assert_eq!(
+            special.export_jsonschemas.as_ref().unwrap(),
+            &vec!["export_jsonschemas".to_string()]
         );
     }
 

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -100,6 +100,10 @@ pub struct SpecialFields {
     /// The field should be `Option<Shell>`.
     pub completions: Option<Path>,
 
+    /// Path to the JSON Schema export field - when set, write schemas and exit 0.
+    /// The field should be `Option<String>`.
+    pub export_jsonschemas: Option<Path>,
+
     /// Path to the `version` field - when true, show version and exit 0.
     /// The field should be a `bool`.
     pub version: Option<Path>,
@@ -758,6 +762,13 @@ impl ConfigVecSchema {
     /// Get the shape of this vec.
     pub fn shape(&self) -> &'static Shape {
         self.shape
+    }
+}
+
+impl LeafSchema {
+    /// Get the leaf kind.
+    pub fn kind(&self) -> &LeafKind {
+        &self.kind
     }
 }
 

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -705,6 +705,9 @@ fn arg_level_from_fields_with_prefix(
             if inner_special.completions.is_some() {
                 special.completions = inner_special.completions;
             }
+            if inner_special.export_jsonschemas.is_some() {
+                special.export_jsonschemas = inner_special.export_jsonschemas;
+            }
 
             // Merge the inner args into our args (checking for conflicts)
             for (name, arg) in inner.args {
@@ -986,6 +989,9 @@ fn arg_level_from_fields_with_prefix(
         }
         if field.has_attr(Some("args"), "completions") {
             special.completions = Some(field_path.clone());
+        }
+        if field.has_attr(Some("args"), "export_jsonschemas") {
+            special.export_jsonschemas = Some(field_path.clone());
         }
 
         let arg = ArgSchema {

--- a/crates/figue/tests/integration/json_schema.rs
+++ b/crates/figue/tests/integration/json_schema.rs
@@ -1,0 +1,123 @@
+use facet::Facet;
+use figue::{self as args, builder};
+use std::fs;
+
+#[derive(Facet, Debug)]
+struct Args {
+    /// Primary configuration
+    #[facet(args::config, args::env_prefix = "APP", rename = "cfg")]
+    cfg: AppConfig,
+
+    /// Evaluation configuration
+    #[facet(args::config, rename = "eval")]
+    eval: EvalConfig,
+}
+
+/// Application config root.
+#[derive(Facet, Debug)]
+struct AppConfig {
+    /// Server hostname.
+    #[facet(default = "localhost")]
+    host: String,
+
+    /// Server port.
+    #[facet(default = 8080)]
+    port: u16,
+
+    /// Maximum retry attempts.
+    #[facet(rename = "max-retries", default = 3)]
+    max_retries: u32,
+
+    /// Additional hostnames.
+    aliases: Vec<String>,
+
+    /// Optional TLS settings.
+    #[facet(default)]
+    tls: Option<TlsConfig>,
+
+    /// Storage backend.
+    storage: Storage,
+
+    /// Log output format.
+    #[facet(default)]
+    format: LogFormat,
+}
+
+#[derive(Facet, Debug)]
+struct TlsConfig {
+    /// Certificate path.
+    cert_path: String,
+
+    /// Private key path.
+    key_path: String,
+}
+
+#[derive(Facet, Debug)]
+#[facet(rename_all = "kebab-case")]
+#[repr(u8)]
+#[allow(dead_code)]
+enum Storage {
+    /// Local filesystem storage.
+    Local {
+        /// Base path.
+        path: String,
+    },
+    /// S3-compatible storage.
+    S3 {
+        /// Bucket name.
+        bucket: String,
+        /// Region name.
+        #[facet(default = "us-east-1")]
+        region: String,
+    },
+    /// In-memory storage.
+    Memory,
+}
+
+#[derive(Facet, Debug, Default)]
+#[repr(u8)]
+enum LogFormat {
+    /// Plain text logs.
+    #[default]
+    Plain,
+    /// JSON logs.
+    Json,
+}
+
+#[derive(Facet, Debug)]
+struct EvalConfig {
+    /// Dataset name.
+    dataset: String,
+
+    /// Sample count.
+    #[facet(default = 10)]
+    samples: u32,
+}
+
+#[test]
+fn test_generate_json_schemas_for_all_config_roots() {
+    let schemas = figue::generate_json_schemas::<Args>().unwrap();
+
+    assert_eq!(schemas.len(), 2);
+    assert_eq!(schemas[0].file_name, "cfg.schema.json");
+    assert_eq!(schemas[1].file_name, "eval.schema.json");
+
+    insta::assert_snapshot!("cfg_json_schema", &schemas[0].contents);
+    insta::assert_snapshot!("eval_json_schema", &schemas[1].contents);
+}
+
+#[test]
+fn test_builder_writes_json_schemas_to_directory() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = builder::<Args>().unwrap();
+
+    let paths = config.write_json_schemas(tempdir.path()).unwrap();
+
+    assert_eq!(paths.len(), 2);
+    assert!(tempdir.path().join("cfg.schema.json").exists());
+    assert!(tempdir.path().join("eval.schema.json").exists());
+
+    let cfg = fs::read_to_string(tempdir.path().join("cfg.schema.json")).unwrap();
+    assert!(cfg.contains(r#""$schema": "https://json-schema.org/draft/2020-12/schema""#));
+    assert!(cfg.contains(r#""description": "Server hostname.""#));
+}

--- a/crates/figue/tests/integration/mod.rs
+++ b/crates/figue/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod deser_errors;
 mod env_subst;
 mod err;
 mod help;
+mod json_schema;
 mod layered;
 mod schema_defaults;
 mod sequence;

--- a/crates/figue/tests/integration/snapshots/main__integration__help__help_simple_struct.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__help__help_simple_struct.snap
@@ -28,3 +28,5 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.

--- a/crates/figue/tests/integration/snapshots/main__integration__help__help_with_subcommands.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__help__help_with_subcommands.snap
@@ -16,6 +16,8 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.
 
 COMMANDS:
     clone

--- a/crates/figue/tests/integration/snapshots/main__integration__help__subcommand_root_help.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__help__subcommand_root_help.snap
@@ -16,6 +16,8 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.
 
 COMMANDS:
     install

--- a/crates/figue/tests/integration/snapshots/main__integration__help__tuple_variant_main_help.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__help__tuple_variant_main_help.snap
@@ -14,6 +14,8 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.
 
 COMMANDS:
     build

--- a/crates/figue/tests/integration/snapshots/main__integration__json_schema__cfg_json_schema.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__json_schema__cfg_json_schema.snap
@@ -1,0 +1,134 @@
+---
+source: crates/figue/tests/integration/json_schema.rs
+expression: "&schemas[0].contents"
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AppConfig",
+  "description": "Primary configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "host": {
+      "type": "string",
+      "description": "Server hostname.",
+      "default": "localhost"
+    },
+    "port": {
+      "type": "integer",
+      "description": "Server port.",
+      "default": 8080
+    },
+    "max-retries": {
+      "type": "integer",
+      "description": "Maximum retry attempts.",
+      "default": 3
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Additional hostnames."
+    },
+    "tls": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cert_path": {
+              "type": "string",
+              "description": "Certificate path."
+            },
+            "key_path": {
+              "type": "string",
+              "description": "Private key path."
+            }
+          },
+          "required": [
+            "cert_path",
+            "key_path"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Optional TLS settings."
+    },
+    "storage": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "local": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "Base path."
+                }
+              },
+              "required": [
+                "path"
+              ]
+            }
+          },
+          "required": [
+            "local"
+          ],
+          "description": "Local filesystem storage."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "s3": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "bucket": {
+                  "type": "string",
+                  "description": "Bucket name."
+                },
+                "region": {
+                  "type": "string",
+                  "description": "Region name.",
+                  "default": "us-east-1"
+                }
+              },
+              "required": [
+                "bucket"
+              ]
+            }
+          },
+          "required": [
+            "s3"
+          ],
+          "description": "S3-compatible storage."
+        },
+        {
+          "const": "memory",
+          "description": "In-memory storage."
+        }
+      ],
+      "description": "Storage backend."
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "Plain",
+        "Json"
+      ],
+      "description": "Log output format.",
+      "default": "Plain"
+    }
+  },
+  "required": [
+    "aliases",
+    "storage"
+  ]
+}

--- a/crates/figue/tests/integration/snapshots/main__integration__json_schema__eval_json_schema.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__json_schema__eval_json_schema.snap
@@ -1,0 +1,25 @@
+---
+source: crates/figue/tests/integration/json_schema.rs
+expression: "&schemas[1].contents"
+---
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvalConfig",
+  "description": "Evaluation configuration",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "dataset": {
+      "type": "string",
+      "description": "Dataset name."
+    },
+    "samples": {
+      "type": "integer",
+      "description": "Sample count.",
+      "default": 10
+    }
+  },
+  "required": [
+    "dataset"
+  ]
+}

--- a/crates/figue/tests/integration/snapshots/main__integration__simple__completions_help_shows_enum_variants.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__simple__completions_help_shows_enum_variants.snap
@@ -15,3 +15,5 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.

--- a/crates/figue/tests/integration/snapshots/main__integration__subcommand_errors__no_subcommand_provided.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__subcommand_errors__no_subcommand_provided.snap
@@ -14,6 +14,8 @@ OPTIONS:
             Show version and exit.
         --completions <bash,zsh,fish>
             Generate shell completions.
+        --export-jsonschemas <DIR>
+            Export JSON Schema files for all config roots.
 
 COMMANDS:
     init


### PR DESCRIPTION
## Summary
- add JSON Schema generation for figue config roots
- expose `generate_json_schemas` / `write_json_schemas` APIs and builder/config helpers
- add built-in `--export-jsonschemas <DIR>` early exit that writes one schema file per config root

Closes #90.

## Testing
- `cargo nextest run`
- `cargo check --all-features --all-targets --message-format=short`
- push hook checks passed: clippy, docs, build tests, run tests