### PR TITLE
Improve config layering and HTML help navigation

### DIFF
--- a/crates/figue/src/builder.rs
+++ b/crates/figue/src/builder.rs
@@ -819,7 +819,6 @@ mod tests {
             .strict()
             .build();
 
-        // explicit_path is set by the driver when CLI provides --config <path>
         assert_eq!(config.explicit_path, None);
         assert_eq!(config.default_paths.len(), 2);
         assert!(config.strict);

--- a/crates/figue/src/builder.rs
+++ b/crates/figue/src/builder.rs
@@ -349,7 +349,7 @@ impl<T> ConfigBuilder<T> {
     /// // Use inline content for testing (avoids file I/O)
     /// let config = builder::<Args>()
     ///     .unwrap()
-    ///     .file(|f| f.content(r#"{"port": 9000}"#, "config.json"))
+    ///     .file(|f| f.content(r#"{"config": {"port": 9000}}"#, "config.json"))
     ///     .build();
     ///
     /// let output = Driver::new(config).run().into_result().unwrap();
@@ -552,7 +552,7 @@ impl HelpConfigBuilder {
 /// // Load from inline JSON (useful for testing)
 /// let config = builder::<Args>()
 ///     .unwrap()
-///     .file(|f| f.content(r#"{"host": "0.0.0.0", "port": 3000}"#, "config.json"))
+///     .file(|f| f.content(r#"{"config": {"host": "0.0.0.0", "port": 3000}}"#, "config.json"))
 ///     .build();
 ///
 /// let output = Driver::new(config).run().into_result().unwrap();
@@ -645,7 +645,7 @@ impl FileConfigBuilder {
     ///
     /// let config = builder::<Args>()
     ///     .unwrap()
-    ///     .file(|f| f.content(r#"{"port": 9000}"#, "test.json"))
+    ///     .file(|f| f.content(r#"{"config": {"port": 9000}}"#, "test.json"))
     ///     .build();
     ///
     /// let output = Driver::new(config).run().into_result().unwrap();

--- a/crates/figue/src/driver.rs
+++ b/crates/figue/src/driver.rs
@@ -62,9 +62,12 @@ pub struct LayerOutput {
     /// For file layers, this is the file contents.
     /// For CLI, this is the concatenated args.
     pub source_text: Option<String>,
-    /// Config file path captured from CLI (e.g., `--config path/to/file.json`).
-    /// Only set by the CLI layer when the user specifies a config file path.
-    pub config_file_path: Option<camino::Utf8PathBuf>,
+    /// Config file paths captured from CLI, keyed by config root field name.
+    ///
+    /// This is used when a schema has multiple `args::config` fields. For
+    /// example, `--cfg cfg.json` should load `cfg.json` as the `cfg` block, not
+    /// as a top-level file containing every config root.
+    pub config_file_paths: indexmap::IndexMap<String, camino::Utf8PathBuf>,
 }
 
 /// A key that was unused by the schema, with provenance.
@@ -184,9 +187,10 @@ impl<T: Facet<'static>> Driver<T> {
         // Phase 1: Parse each layer
         // Priority order (lowest to highest): defaults < file < env < cli
         //
-        // Note: CLI is parsed first to capture the config file path (--config <path>),
-        // which is then used by the file layer. The priority ordering is enforced
-        // during the merge phase, not the parse phase.
+        // Note: CLI is parsed first to capture config-root file paths
+        // (`--config <path>`, `--cfg <path>`, etc.), which are then used by the
+        // file layer. The priority ordering is enforced during the merge phase,
+        // not the parse phase.
 
         // 1a. Defaults layer (TODO: extract defaults from schema)
         // For now, defaults is empty - this will be filled in when we implement
@@ -201,10 +205,10 @@ impl<T: Facet<'static>> Driver<T> {
 
         // 1c. File layer (uses config file path from CLI if provided)
         // If CLI provided a config file path, update the file config to use it
-        if let Some(ref cli_path) = layers.cli.config_file_path {
+        if !layers.cli.config_file_paths.is_empty() {
             // Get mutable access to file_config, creating a default if none exists
             let file_config = self.config.file_config.get_or_insert_with(Default::default);
-            file_config.explicit_path = Some(cli_path.clone());
+            file_config.explicit_paths_by_root = layers.cli.config_file_paths.clone();
         }
 
         if let Some(ref file_config) = self.config.file_config {

--- a/crates/figue/src/driver.rs
+++ b/crates/figue/src/driver.rs
@@ -736,6 +736,10 @@ impl<T: Facet<'static>> Driver<T> {
         // Phase 4: Assign virtual spans and deserialize into T
         // The span registry maps virtual spans back to real source locations
         let mut value_with_virtual_spans = value_with_defaults;
+        flatten_config_roots_for_deserialization(
+            &mut value_with_virtual_spans,
+            &self.config.schema,
+        );
         let span_registry = assign_virtual_spans(&mut value_with_virtual_spans);
 
         let value: T = match from_config_value(&value_with_virtual_spans) {
@@ -792,6 +796,40 @@ impl<T: Facet<'static>> Driver<T> {
             merged_config: value_with_virtual_spans,
             schema: self.config.schema.clone(),
         })
+    }
+}
+
+fn flatten_config_roots_for_deserialization(
+    value: &mut ConfigValue,
+    schema: &crate::schema::Schema,
+) {
+    let ConfigValue::Object(root) = value else {
+        return;
+    };
+
+    for config_schema in schema.configs() {
+        if !config_schema.flattened_root() {
+            continue;
+        }
+
+        let Some(field_name) = config_schema.field_name() else {
+            continue;
+        };
+
+        let Some(config_value) = root.value.shift_remove(field_name) else {
+            continue;
+        };
+
+        match config_value {
+            ConfigValue::Object(config_object) => {
+                for (key, value) in config_object.value {
+                    root.value.insert(key, value);
+                }
+            }
+            other => {
+                root.value.insert(field_name.to_string(), other);
+            }
+        }
     }
 }
 

--- a/crates/figue/src/help.rs
+++ b/crates/figue/src/help.rs
@@ -5,8 +5,8 @@
 
 use crate::missing::normalize_program_name;
 use crate::schema::{
-    ArgLevelSchema, ArgSchema, ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, Schema,
-    Subcommand,
+    ArgLevelSchema, ArgSchema, ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, Docs,
+    Schema, Subcommand,
 };
 use facet_core::Facet;
 use heck::ToKebabCase;
@@ -491,7 +491,7 @@ fn render_html_help_document(doc: HtmlHelpDocument<'_>) -> String {
         "    .topbar-inner { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 10px 0; display: grid; grid-template-columns: minmax(160px, auto) minmax(240px, 1fr); gap: 16px; align-items: center; } .topbar-title { font-weight: 750; font-size: 1rem; white-space: nowrap; }\n",
     );
     out.push_str(
-        "    .layout { width: min(1180px, calc(100% - 32px)); margin: 28px auto 72px; display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 28px; align-items: start; } main { min-width: 0; } .side-nav { position: sticky; top: 76px; display: flex; flex-direction: column; gap: 3px; padding-left: 12px; border-left: 2px solid var(--line); font-size: .9rem; } .side-nav-title { margin: 0 0 8px; color: var(--muted); font-size: .72rem; font-weight: 750; text-transform: uppercase; letter-spacing: .08em; } .side-nav a { color: var(--muted); text-decoration: none; padding: 4px 0; } .side-nav a.nav-section { color: var(--fg); font-weight: 650; } .side-nav a.nav-command { padding-left: 12px; font-size: .86rem; } .side-nav a:hover { color: var(--accent); }\n",
+        "    .layout { width: min(1180px, calc(100% - 32px)); margin: 28px auto 72px; display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 28px; align-items: start; } main { min-width: 0; } .side-nav { position: sticky; top: 76px; max-height: calc(100vh - 92px); overflow-y: auto; display: flex; flex-direction: column; gap: 3px; padding-left: 12px; padding-right: 8px; border-left: 2px solid var(--line); font-size: .9rem; scrollbar-width: thin; } .side-nav-title { margin: 0 0 8px; color: var(--muted); font-size: .72rem; font-weight: 750; text-transform: uppercase; letter-spacing: .08em; } .side-nav a { color: var(--muted); text-decoration: none; padding: 4px 0; } .side-nav a.nav-section { color: var(--fg); font-weight: 650; } .side-nav a.nav-command { padding-left: 12px; font-size: .86rem; } .side-nav a:hover { color: var(--accent); }\n",
     );
     out.push_str(
         "    header { max-width: 74ch; border-bottom: 1px solid var(--line); padding-bottom: 28px; margin-bottom: 30px; } h1 { margin: 0 0 8px; font-size: clamp(2rem, 4vw, 2.45rem); line-height: 1.08; letter-spacing: 0; } h2 { margin: 34px 0 14px; font-size: 1.02rem; line-height: 1.2; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); scroll-margin-top: 82px; } h3 { margin: 20px 0 10px; font-size: 1.02rem; line-height: 1.35; scroll-margin-top: 82px; }\n",
@@ -515,7 +515,7 @@ fn render_html_help_document(doc: HtmlHelpDocument<'_>) -> String {
         "    code { font: .93em/1.45 \"Maple Mono\", ui-monospace, SFMono-Regular, Consolas, \"Liberation Mono\", monospace; background: var(--code); color: var(--fg); border-radius: 4px; padding: 2px 5px; white-space: nowrap; vertical-align: .03em; } code.value-token { background: var(--value-bg); color: var(--value-fg); } code.env-token { background: var(--env-bg); color: var(--env-fg); } .names { width: 32%; } .empty { color: var(--muted); } .badge { display: inline-block; margin: 2px 4px 2px 0; padding: 2px 7px; border-radius: 999px; background: var(--soft); color: var(--accent); font-size: .82rem; font-weight: 600; }\n",
     );
     out.push_str(
-        "    details.schema-node, details.command-card { margin: 10px 0; padding: 10px 12px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); } details.inline-schema { margin-top: 12px; } details.schema-node details.schema-node { margin-left: 18px; background: transparent; } summary { cursor: pointer; font-weight: 650; list-style: none; } summary::-webkit-details-marker { display: none; } details > summary::before { content: \"+\"; display: inline-grid; place-items: center; width: 1.1em; margin-right: 4px; color: var(--accent); font-weight: 750; } details[open] > summary::before { content: \"-\"; } details::details-content { block-size: 0; overflow: clip; transition: block-size .22s ease, content-visibility .22s allow-discrete; } details[open]::details-content { block-size: auto; } @media (prefers-reduced-motion: reduce) { details::details-content { transition: none; } } .node-body, .command-body { margin-top: 8px; padding-left: 2px; } .node-grid { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(100px, auto); gap: 8px 16px; align-items: start; } .config-field { display: grid; grid-template-columns: minmax(180px, 32%) minmax(0, 1fr); gap: 12px 20px; padding: 10px 0; border-bottom: 1px solid var(--line); } .config-field:last-child { border-bottom: 0; } .config-desc p:last-child { margin-bottom: 0; } .override-details { margin-top: 8px; color: var(--muted); font-size: .9rem; } .override-details summary { font-weight: 600; } .override-grid { display: grid; grid-template-columns: auto 3.2em minmax(0, max-content) max-content; gap: 5px 8px; align-items: center; margin-top: 6px; } .copy-button { width: 1.55rem; height: 1.55rem; padding: 0; display: inline-grid; place-items: center; border: 1px solid var(--line); border-radius: 5px; background: var(--panel); color: var(--muted); cursor: pointer; } .copy-button svg { width: .9rem; height: .9rem; stroke: currentColor; } .copy-button:hover { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); } .copy-button.is-copied { color: var(--accent); background: var(--soft); } .override-label { color: var(--muted); font-weight: 650; } .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; } .layer-examples { display: grid; gap: 4px; }\n",
+        "    details.schema-node, details.command-card { margin: 10px 0; padding: 10px 12px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); } details.inline-schema { margin-top: 12px; } details.schema-node details.schema-node { margin-left: 18px; background: transparent; } summary { cursor: pointer; font-weight: 650; list-style: none; } summary::-webkit-details-marker { display: none; } details > summary::before { content: \"+\"; display: inline-grid; place-items: center; width: 1.1em; margin-right: 4px; color: var(--accent); font-weight: 750; } details[open] > summary::before { content: \"-\"; } details::details-content { block-size: 0; overflow: clip; transition: block-size .22s ease, content-visibility .22s allow-discrete; } details[open]::details-content { block-size: auto; } @media (prefers-reduced-motion: reduce) { details::details-content { transition: none; } } .node-body, .command-body { margin-top: 8px; padding-left: 2px; } .node-grid { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(100px, auto); gap: 8px 16px; align-items: start; } .config-field { display: grid; grid-template-columns: minmax(0, 34%) minmax(0, 1fr); gap: 12px 20px; padding: 10px 0; border-bottom: 1px solid var(--line); } .config-field:last-child { border-bottom: 0; } .config-name, .config-desc { min-width: 0; } .config-name code { white-space: normal; overflow-wrap: anywhere; word-break: break-word; } .config-desc p:last-child { margin-bottom: 0; } .override-details { margin-top: 8px; color: var(--muted); font-size: .9rem; } .override-details summary { font-weight: 600; } .override-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 5px 8px; align-items: center; margin-top: 6px; } .override-grid code { min-width: 0; white-space: normal; overflow-wrap: anywhere; word-break: break-word; } .copy-button { width: 1.55rem; height: 1.55rem; padding: 0; display: inline-grid; place-items: center; border: 1px solid var(--line); border-radius: 5px; background: var(--panel); color: var(--muted); cursor: pointer; } .copy-button svg { width: .9rem; height: .9rem; stroke: currentColor; } .copy-button:hover { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--line)); } .copy-button.is-copied { color: var(--accent); background: var(--soft); } .override-label { color: var(--muted); font-weight: 650; display: inline-flex; align-items: center; gap: 6px; } .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; } .layer-examples { display: grid; gap: 4px; }\n",
     );
     out.push_str(
         "    .config-schema-panel { margin-top: 16px; padding: 14px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); }\n",
@@ -868,8 +868,8 @@ fn render_html_arg_row(out: &mut String, arg: &ArgSchema) {
     }
     render_arg_name_meta(out, arg);
     out.push_str("</td><td>");
-    if let Some(summary) = arg.docs().summary() {
-        push_markdown(out, summary.trim());
+    if arg.docs().summary().is_some() || arg.docs().details().is_some() {
+        render_html_docs(out, arg.docs());
     } else {
         out.push_str("<span class=\"empty\">No description.</span>");
     }
@@ -1118,7 +1118,7 @@ fn render_html_config_field_node(
             render_default_summary(out, field.default());
             out.push_str("</summary>\n<div class=\"node-body\">\n");
             render_config_field_docs(out, field);
-            render_config_override_details(out, path, field.value(), env_prefix);
+            render_config_override_details(out, path, env_prefix);
             let item_path = join_path(path, "<INDEX>");
             render_html_config_value_node(
                 out,
@@ -1139,7 +1139,7 @@ fn render_html_config_field_node(
             render_default_summary(out, field.default());
             out.push_str("</summary>\n<div class=\"node-body\">\n");
             render_config_field_docs(out, field);
-            render_config_override_details(out, path, field.value(), env_prefix);
+            render_config_override_details(out, path, env_prefix);
             for (variant_name, variant) in enum_schema.variants() {
                 out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
                 push_escaped(out, variant_name);
@@ -1211,7 +1211,7 @@ fn render_html_config_value_node(
             out.push_str("</code> <span class=\"meta\">enum ");
             push_escaped(out, value.type_identifier());
             out.push_str("</span></summary>\n<div class=\"node-body\">\n");
-            render_config_override_details(out, path, value, env_prefix);
+            render_config_override_details(out, path, env_prefix);
             for variant_name in enum_schema.variants().keys() {
                 out.push_str("<p><code>");
                 push_escaped(out, variant_name);
@@ -1225,7 +1225,7 @@ fn render_html_config_value_node(
             out.push_str("</code> <span class=\"meta\">");
             push_escaped(out, value.type_identifier());
             out.push_str("</span>");
-            render_config_override_details(out, path, value, env_prefix);
+            render_config_override_details(out, path, env_prefix);
             out.push_str("</div></div>\n");
         }
         ConfigValueSchema::Option { .. } => unreachable!("inner_if_option removes Option wrappers"),
@@ -1246,45 +1246,35 @@ fn render_html_config_leaf_node(
     out.push_str("</code> <span class=\"meta\">");
     push_escaped(out, field.value().type_identifier());
     out.push_str("</span>");
-    render_config_default_meta(out, field.default());
+    render_config_default_meta(out, field.value(), field.default());
     out.push_str("</div><div class=\"config-desc\">");
     render_config_field_docs(out, field);
-    render_config_override_details(out, path, field.value(), env_prefix);
+    render_config_override_details(out, path, env_prefix);
     out.push_str("</div></div>\n");
 }
 
 fn render_config_field_docs(out: &mut String, field: &ConfigFieldSchema) {
-    if let Some(summary) = field.docs().summary() {
-        out.push_str("<p>");
-        push_markdown(out, summary.trim());
-        out.push_str("</p>\n");
+    if field.docs().summary().is_some() || field.docs().details().is_some() {
+        render_html_docs(out, field.docs());
     }
 }
 
-fn render_config_override_details(
-    out: &mut String,
-    path: &str,
-    value: &ConfigValueSchema,
-    env_prefix: Option<&str>,
-) {
+fn render_config_override_details(out: &mut String, path: &str, env_prefix: Option<&str>) {
     out.push_str("<details class=\"override-details\"><summary>Overrides</summary>\n");
     out.push_str("<div class=\"override-grid\">\n");
     let cli_flag = format!("--{path}");
+    out.push_str("<span class=\"override-label\">");
     render_copy_button(out, &cli_flag);
-    out.push_str("<span class=\"override-label\">CLI</span><code>");
+    out.push_str("CLI</span><code>");
     push_escaped(out, &cli_flag);
-    out.push_str("</code><code class=\"value-token\">");
-    push_escaped(
-        out,
-        &format!("<{}>", value.type_identifier().to_uppercase()),
-    );
     out.push_str("</code>\n");
     if let Some(env_prefix) = env_prefix {
         let env_name = env_override_name(env_prefix, path);
+        out.push_str("<span class=\"override-label\">");
         render_copy_button(out, &env_name);
-        out.push_str("<span class=\"override-label\">Env</span><code class=\"env-token\">");
+        out.push_str("Env</span><code class=\"env-token\">");
         push_escaped(out, &env_name);
-        out.push_str("</code><code class=\"value-token\">=...</code>\n");
+        out.push_str("</code>\n");
     }
     out.push_str("</div>\n</details>\n");
 }
@@ -1301,14 +1291,23 @@ fn render_copy_button(out: &mut String, value: &str) {
 
 fn render_config_default_meta(
     out: &mut String,
+    value: &ConfigValueSchema,
     default: Option<&crate::config_value::ConfigValue>,
 ) {
+    let false_bool_default =
+        value.is_bool() && default.map(config_value_summary).as_deref() == Some("false");
+    if false_bool_default || (default.is_none() && value.is_bool()) {
+        return;
+    }
+
     out.push_str("<span class=\"name-meta\">");
     if let Some(default) = default {
         out.push_str("Default ");
         out.push_str("<code class=\"value-token\">");
         push_escaped(out, &config_value_summary(default));
         out.push_str("</code>");
+    } else if value.is_option() {
+        out.push_str("Optional");
     } else {
         out.push_str("Required");
     }
@@ -1609,6 +1608,34 @@ function escapeRegExp(value) {
 </script>
 "#,
     );
+}
+
+fn render_html_docs(out: &mut String, docs: &Docs) {
+    let mut text = String::new();
+    if let Some(summary) = docs.summary() {
+        text.push_str(summary.trim());
+    }
+    if let Some(details) = docs.details() {
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(details.trim());
+    }
+
+    for paragraph in text.split("\n\n") {
+        let paragraph = paragraph
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if paragraph.is_empty() {
+            continue;
+        }
+        out.push_str("<p>");
+        push_markdown(out, &paragraph);
+        out.push_str("</p>\n");
+    }
 }
 
 fn push_markdown(out: &mut String, text: &str) {
@@ -2301,6 +2328,7 @@ mod tests {
         assert!(html.contains("Input &lt;path&gt; to process"));
         assert!(html.contains("--[no-]verbose"));
         assert!(html.contains("<nav class=\"side-nav\""));
+        assert!(html.contains("max-height: calc(100vh - 92px); overflow-y: auto;"));
         assert!(html.contains("On This Page"));
         assert!(html.contains("Top-Level Options"));
         assert!(html.contains("data-collapsible-intro"));
@@ -2346,8 +2374,12 @@ mod tests {
         assert!(html.contains("data-copy=\"--settings.server.port\""));
         assert!(html.contains("<code class=\"env-token\">APP__SERVER__PORT</code>"));
         assert!(html.contains("data-copy=\"APP__SERVER__PORT\""));
-        assert!(html.contains("<code class=\"value-token\">&lt;U16&gt;</code>"));
-        assert!(html.contains("<code class=\"value-token\">=...</code>"));
+        assert!(!html.contains(
+            "<code>--settings.server.port</code><code class=\"value-token\">&lt;U16&gt;</code>"
+        ));
+        assert!(!html.contains(
+            "<code class=\"env-token\">APP__SERVER__PORT</code><code class=\"value-token\">=...</code>"
+        ));
         assert!(
             html.contains(
                 "<code>--settings</code> <code class=\"value-token\">settings.json</code>"
@@ -2362,6 +2394,54 @@ mod tests {
         assert!(html.contains("Default <code class=\"value-token\">8080</code>"));
         assert!(!html.contains("config-schema-heading"));
         assert!(!html.contains("--settings.server.port &lt;U16&gt;</code></td><td>"));
+        assert!(html.contains(".config-name code { white-space: normal;"));
+        assert!(html.contains(
+            ".override-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr);"
+        ));
+    }
+
+    #[test]
+    fn test_html_help_config_meta_matches_implicit_defaults() {
+        #[derive(Facet)]
+        struct Args {
+            #[facet(args::config)]
+            settings: Settings,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Settings {
+            /// Enables the feature.
+            #[facet(default)]
+            enabled: bool,
+
+            /// Optional queue size.
+            queue_size: Option<usize>,
+
+            /// Implicitly false when omitted.
+            implicit_flag: bool,
+        }
+
+        let html = generate_html_help::<Args>(&HelpConfig::default());
+
+        assert!(!html.contains("Default <code class=\"value-token\">false</code>"));
+        assert!(!html.contains("<code>implicit_flag</code> <span class=\"meta\">bool</span><span class=\"name-meta\">Required</span>"));
+        assert!(html.contains("<code>queue_size</code> <span class=\"meta\">usize</span><span class=\"name-meta\">Optional</span>"));
+    }
+
+    #[test]
+    fn test_html_help_arg_rows_include_wrapped_doc_details() {
+        #[derive(Facet)]
+        struct Args {
+            /// Output path for the alignment JSONL (one
+            /// object per line).
+            #[facet(args::named)]
+            out: Option<String>,
+        }
+
+        let html = generate_html_help::<Args>(&HelpConfig::default());
+
+        assert!(html.contains("<p>Output path for the alignment JSONL (one object per line).</p>"));
     }
 
     #[test]

--- a/crates/figue/src/help.rs
+++ b/crates/figue/src/help.rs
@@ -5,8 +5,8 @@
 
 use crate::missing::normalize_program_name;
 use crate::schema::{
-    ArgLevelSchema, ArgSchema, ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, Docs,
-    Schema, Subcommand,
+    ArgLevelSchema, ArgSchema, ConfigFieldGroupSchema, ConfigFieldSchema, ConfigStructSchema,
+    ConfigValueSchema, Docs, Schema, Subcommand,
 };
 use facet_core::Facet;
 use heck::ToKebabCase;
@@ -488,13 +488,16 @@ fn render_html_help_document(doc: HtmlHelpDocument<'_>) -> String {
         "    .topbar { position: sticky; top: 0; z-index: 10; border-bottom: 1px solid var(--line); background: color-mix(in srgb, var(--bg) 92%, transparent); backdrop-filter: blur(12px); }\n",
     );
     out.push_str(
-        "    .topbar-inner { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 10px 0; display: grid; grid-template-columns: minmax(160px, auto) minmax(240px, 1fr); gap: 16px; align-items: center; } .topbar-title { font-weight: 750; font-size: 1rem; white-space: nowrap; }\n",
+        "    .topbar-inner { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 10px 0 6px; display: grid; grid-template-columns: minmax(160px, auto) minmax(240px, 1fr); gap: 16px; align-items: center; } .topbar-title { font-weight: 750; font-size: 1rem; white-space: nowrap; }\n",
+    );
+    out.push_str(
+        "    .breadcrumbs { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 0 0 9px; color: var(--muted); font-size: .82rem; overflow-x: auto; scrollbar-width: thin; } .breadcrumbs ol { display: flex; align-items: center; gap: 0; min-height: 1.45rem; margin: 0; padding: 0; list-style: none; white-space: nowrap; } .breadcrumbs li { display: inline-flex; align-items: center; min-width: 0; } .breadcrumbs li + li::before { content: \"/\"; margin: 0 5px; color: color-mix(in srgb, var(--muted) 62%, transparent); } .breadcrumbs a { display: inline-block; max-width: 26ch; overflow: hidden; text-overflow: ellipsis; color: var(--muted); text-decoration: none; border-radius: 4px; padding: 1px 4px; } .breadcrumbs a:hover { color: var(--accent); background: var(--soft); } .breadcrumbs li:last-child a { color: var(--fg); font-weight: 650; }\n",
     );
     out.push_str(
         "    .layout { width: min(1180px, calc(100% - 32px)); margin: 28px auto 72px; display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 28px; align-items: start; } main { min-width: 0; } .side-nav { position: sticky; top: 76px; max-height: calc(100vh - 92px); overflow-y: auto; display: flex; flex-direction: column; gap: 3px; padding-left: 12px; padding-right: 8px; border-left: 2px solid var(--line); font-size: .9rem; scrollbar-width: thin; } .side-nav-title { margin: 0 0 8px; color: var(--muted); font-size: .72rem; font-weight: 750; text-transform: uppercase; letter-spacing: .08em; } .side-nav a { color: var(--muted); text-decoration: none; padding: 4px 0; } .side-nav a.nav-section { color: var(--fg); font-weight: 650; } .side-nav a.nav-command { padding-left: 12px; font-size: .86rem; } .side-nav a:hover { color: var(--accent); }\n",
     );
     out.push_str(
-        "    header { max-width: 74ch; border-bottom: 1px solid var(--line); padding-bottom: 28px; margin-bottom: 30px; } h1 { margin: 0 0 8px; font-size: clamp(2rem, 4vw, 2.45rem); line-height: 1.08; letter-spacing: 0; } h2 { margin: 34px 0 14px; font-size: 1.02rem; line-height: 1.2; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); scroll-margin-top: 82px; } h3 { margin: 20px 0 10px; font-size: 1.02rem; line-height: 1.35; scroll-margin-top: 82px; }\n",
+        "    header { max-width: 74ch; border-bottom: 1px solid var(--line); padding-bottom: 28px; margin-bottom: 30px; } h1 { margin: 0 0 8px; font-size: clamp(2rem, 4vw, 2.45rem); line-height: 1.08; letter-spacing: 0; } h2 { margin: 34px 0 14px; font-size: 1.02rem; line-height: 1.2; text-transform: uppercase; letter-spacing: .08em; color: var(--muted); scroll-margin-top: 118px; } h3 { margin: 20px 0 10px; font-size: 1.02rem; line-height: 1.35; scroll-margin-top: 118px; } section, details.schema-node, details.command-card, .config-schema-panel, .schema-node { scroll-margin-top: 118px; }\n",
     );
     out.push_str(
         "    p { margin: 0 0 .85rem; max-width: 72ch; } a { color: var(--accent); text-underline-offset: 2px; } .summary { font-size: 1.12rem; line-height: 1.55; color: var(--fg); } .description, .details, .meta, .name-meta { color: var(--muted); } .details p + p { margin-top: .95rem; } .meta, .name-meta { font-size: .9rem; line-height: 1.45; } .name-meta { display: block; margin-top: 7px; } .intro-copy { position: relative; max-height: 13.5rem; overflow: hidden; } .intro-copy.is-expanded { max-height: none; } .intro-copy:not(.is-expanded)::after { content: \"\"; position: absolute; inset: auto 0 0; height: 48px; background: linear-gradient(transparent, var(--bg)); pointer-events: none; } .intro-toggle { margin-top: 4px; padding: 6px 10px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); color: var(--fg); font: inherit; cursor: pointer; } .markdown-body > :first-child { margin-top: 0; } .markdown-body p { margin-bottom: .85rem; } .markdown-body ul, .markdown-body ol { margin: 0 0 .9rem 1.4rem; padding: 0; } .markdown-body li { margin: .25rem 0; }\n",
@@ -526,10 +529,12 @@ fn render_html_help_document(doc: HtmlHelpDocument<'_>) -> String {
     out.push_str("  </style>\n</head>\n<body>\n");
     out.push_str("<div class=\"topbar\"><div class=\"topbar-inner\"><div class=\"topbar-title\">");
     push_escaped(&mut out, doc.command);
-    out.push_str("</div><input class=\"search\" type=\"search\" placeholder=\"Search flags, commands, config paths, defaults (Cmd/Ctrl-K)\" aria-label=\"Search help\"></div></div>\n");
+    out.push_str("</div><input class=\"search\" type=\"search\" placeholder=\"Search flags, commands, config paths, defaults (Cmd/Ctrl-K)\" aria-label=\"Search help\"></div><nav class=\"breadcrumbs\" aria-label=\"Breadcrumb\"><ol data-breadcrumbs><li><a href=\"#top\">");
+    push_escaped(&mut out, doc.command);
+    out.push_str("</a></li></ol></nav></div>\n");
     out.push_str("<div class=\"layout\">\n");
     render_html_side_nav(&mut out, doc.args, doc.config_roots);
-    out.push_str("<main>\n<header>\n");
+    out.push_str("<main id=\"top\">\n<header>\n");
     out.push_str("  <h1>");
     push_escaped(&mut out, doc.command);
     out.push_str("</h1>\n");
@@ -628,7 +633,9 @@ fn render_html_usage(
     config_roots: &[ConfigStructSchema],
     command: &str,
 ) {
-    out.push_str("<section aria-labelledby=\"usage-heading\">\n");
+    out.push_str(
+        "<section aria-labelledby=\"usage-heading\" data-breadcrumb-label=\"Usage\" data-breadcrumb-anchor=\"usage-heading\">\n",
+    );
     out.push_str("  <h2 id=\"usage-heading\">Usage</h2>\n");
     out.push_str("  <code class=\"usage\">");
     push_escaped(out, command);
@@ -673,7 +680,9 @@ fn render_html_command_sections(out: &mut String, args: &ArgLevelSchema, command
         return;
     }
 
-    out.push_str("<section aria-labelledby=\"commands-heading\">\n");
+    out.push_str(
+        "<section aria-labelledby=\"commands-heading\" data-breadcrumb-label=\"Commands\" data-breadcrumb-anchor=\"commands-heading\">\n",
+    );
     out.push_str("  <h2 id=\"commands-heading\">Commands</h2>\n");
     for sub in args.subcommands().values() {
         render_html_command_card(out, sub, &[sub.cli_name()], command);
@@ -683,7 +692,11 @@ fn render_html_command_sections(out: &mut String, args: &ArgLevelSchema, command
 
 fn render_html_command_card(out: &mut String, sub: &Subcommand, path: &[&str], root_command: &str) {
     let heading_id = command_heading_id(path);
-    out.push_str("<details class=\"command-card search-item\">\n<summary id=\"");
+    out.push_str("<details class=\"command-card search-item\" data-breadcrumb-label=\"");
+    push_escaped(out, sub.cli_name());
+    out.push_str("\" data-breadcrumb-anchor=\"");
+    push_escaped(out, &heading_id);
+    out.push_str("\">\n<summary id=\"");
     push_escaped(out, &heading_id);
     out.push_str("\"><code>");
     push_escaped(out, sub.cli_name());
@@ -768,7 +781,9 @@ fn render_html_arg_level_tables(
         .collect();
 
     if !positionals.is_empty() {
-        out.push_str("<h3>");
+        out.push_str("<h3 data-breadcrumb-label=\"");
+        push_escaped(out, positionals_title);
+        out.push_str("\">");
         push_escaped(out, positionals_title);
         out.push_str("</h3>\n<table>\n  <thead><tr><th>Name</th><th>Description</th></tr></thead>\n  <tbody>\n");
         for arg in positionals {
@@ -778,7 +793,9 @@ fn render_html_arg_level_tables(
     }
 
     if !flags.is_empty() {
-        out.push_str("<h3>");
+        out.push_str("<h3 data-breadcrumb-label=\"");
+        push_escaped(out, flags_title);
+        out.push_str("\">");
         push_escaped(out, flags_title);
         out.push_str("</h3>\n<table>\n  <thead><tr><th>Name</th><th>Description</th></tr></thead>\n  <tbody>\n");
         for arg in flags {
@@ -797,7 +814,7 @@ fn render_html_layer_summary(
         return;
     }
 
-    out.push_str("<section aria-labelledby=\"layers-heading\" class=\"search-item\">\n");
+    out.push_str("<section aria-labelledby=\"layers-heading\" class=\"search-item\" data-breadcrumb-label=\"Configuration\" data-breadcrumb-anchor=\"layers-heading\">\n");
     out.push_str("  <h2 id=\"layers-heading\">Configuration</h2>\n");
     out.push_str("  <p>When a field is set in more than one place, precedence is <span class=\"badge\">CLI</span> &gt; <span class=\"badge\">Environment</span> &gt; <span class=\"badge\">Config file</span> &gt; <span class=\"badge\">Defaults</span>.</p>\n");
     out.push_str("  <p class=\"description\">Supported file formats: ");
@@ -848,6 +865,10 @@ fn render_html_arg_sections(
 
 fn render_html_table_start(out: &mut String, id: &str, title: &str) {
     out.push_str("<section aria-labelledby=\"");
+    push_escaped(out, id);
+    out.push_str("-heading\" data-breadcrumb-label=\"");
+    push_escaped(out, title);
+    out.push_str("\" data-breadcrumb-anchor=\"");
     push_escaped(out, id);
     out.push_str("-heading\">\n  <h2 id=\"");
     push_escaped(out, id);
@@ -978,6 +999,34 @@ fn config_schema_heading_id(root_name: &str) -> String {
     format!("config-fields-{}", root_name.to_kebab_case())
 }
 
+fn config_node_id(path: &str) -> String {
+    let mut id = String::from("config-node-");
+    let mut last_was_dash = true;
+    for c in path.chars() {
+        let next = if c.is_ascii_alphanumeric() {
+            Some(c.to_ascii_lowercase())
+        } else if matches!(c, '-' | '_' | '.' | '<' | '>') {
+            Some('-')
+        } else {
+            None
+        };
+
+        let Some(next) = next else {
+            continue;
+        };
+        if next == '-' {
+            if last_was_dash {
+                continue;
+            }
+            last_was_dash = true;
+        } else {
+            last_was_dash = false;
+        }
+        id.push(next);
+    }
+    id.trim_end_matches('-').to_string()
+}
+
 fn config_file_example(root_name: &str, extensions: &[&str]) -> String {
     let extension = extensions
         .iter()
@@ -1027,7 +1076,11 @@ fn render_html_config_schema_panel(out: &mut String, config_root: &ConfigStructS
         return;
     };
 
-    out.push_str("<div class=\"config-schema-panel search-item\">\n");
+    out.push_str("<div class=\"config-schema-panel search-item\" data-breadcrumb-label=\"");
+    push_escaped(out, &format!("Config fields for {root_path}"));
+    out.push_str("\" data-breadcrumb-anchor=\"");
+    push_escaped(out, &config_schema_heading_id(root_path));
+    out.push_str("\">\n");
     out.push_str("<h3 id=\"");
     push_escaped(out, &config_schema_heading_id(root_path));
     out.push_str("\">Config fields for <code>");
@@ -1040,17 +1093,7 @@ fn render_html_config_schema_panel(out: &mut String, config_root: &ConfigStructS
         out.push_str("</code></p>\n");
     }
 
-    for (field_name, field) in config_root.fields() {
-        let child_path = join_path(root_path, field_name);
-        render_html_config_field_node(
-            out,
-            field_name,
-            &child_path,
-            field,
-            1,
-            config_root.env_prefix(),
-        );
-    }
+    render_html_config_struct_children(out, config_root, root_path, 1, config_root.env_prefix());
 
     out.push_str("</div>\n</div>\n");
 }
@@ -1064,7 +1107,14 @@ fn render_html_config_struct_node(
     env_prefix: Option<&str>,
 ) {
     let name = display_name.unwrap_or("config");
-    out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
+    let node_id = config_node_id(path);
+    out.push_str("<details id=\"");
+    push_escaped(out, &node_id);
+    out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+    push_escaped(out, name);
+    out.push_str("\" data-breadcrumb-anchor=\"");
+    push_escaped(out, &node_id);
+    out.push_str("\">\n<summary><code>");
     push_escaped(out, name);
     out.push_str("</code> <span class=\"meta\">struct ");
     push_escaped(out, config_struct.shape().type_identifier);
@@ -1084,11 +1134,106 @@ fn render_html_config_struct_node(
         out.push_str("</code></p>\n");
     }
 
-    for (field_name, field) in config_struct.fields() {
-        let child_path = join_path(path, field_name);
-        render_html_config_field_node(out, field_name, &child_path, field, depth + 1, env_prefix);
+    render_html_config_struct_children(out, config_struct, path, depth + 1, env_prefix);
+
+    out.push_str("</div>\n</details>\n");
+}
+
+fn render_html_config_struct_children(
+    out: &mut String,
+    config_struct: &ConfigStructSchema,
+    path: &str,
+    depth: usize,
+    env_prefix: Option<&str>,
+) {
+    render_html_config_children(
+        out,
+        config_struct.fields(),
+        config_struct.field_groups(),
+        path,
+        path,
+        depth,
+        env_prefix,
+    );
+}
+
+fn render_html_config_group_children(
+    out: &mut String,
+    group: &ConfigFieldGroupSchema,
+    config_path: &str,
+    group_path: &str,
+    depth: usize,
+    env_prefix: Option<&str>,
+) {
+    render_html_config_children(
+        out,
+        group.fields(),
+        group.field_groups(),
+        config_path,
+        group_path,
+        depth,
+        env_prefix,
+    );
+}
+
+fn render_html_config_children(
+    out: &mut String,
+    fields: &indexmap::IndexMap<String, ConfigFieldSchema, std::hash::RandomState>,
+    groups: &[ConfigFieldGroupSchema],
+    config_path: &str,
+    group_path: &str,
+    depth: usize,
+    env_prefix: Option<&str>,
+) {
+    for (field_name, field) in fields {
+        if config_field_is_grouped(groups, field_name) {
+            continue;
+        }
+        let child_path = join_path(config_path, field_name);
+        render_html_config_field_node(out, field_name, &child_path, field, depth, env_prefix);
     }
 
+    for group in groups {
+        let child_group_path = join_path(&join_path(group_path, "__group"), group.name());
+        render_html_config_field_group(
+            out,
+            group,
+            config_path,
+            &child_group_path,
+            depth,
+            env_prefix,
+        );
+    }
+}
+
+fn config_field_is_grouped(groups: &[ConfigFieldGroupSchema], field_name: &str) -> bool {
+    groups
+        .iter()
+        .any(|group| group.fields().contains_key(field_name))
+}
+
+fn render_html_config_field_group(
+    out: &mut String,
+    group: &ConfigFieldGroupSchema,
+    config_path: &str,
+    group_path: &str,
+    depth: usize,
+    env_prefix: Option<&str>,
+) {
+    let group_id = config_node_id(group_path);
+    out.push_str("<details id=\"");
+    push_escaped(out, &group_id);
+    out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+    push_escaped(out, group.name());
+    out.push_str("\" data-breadcrumb-anchor=\"");
+    push_escaped(out, &group_id);
+    out.push_str("\">\n<summary><code>");
+    push_escaped(out, group.name());
+    out.push_str(
+        "</code> <span class=\"meta\">group</span></summary>\n<div class=\"node-body\">\n",
+    );
+    render_html_docs(out, group.docs());
+    render_html_config_group_children(out, group, config_path, group_path, depth + 1, env_prefix);
     out.push_str("</div>\n</details>\n");
 }
 
@@ -1112,7 +1257,14 @@ fn render_html_config_field_node(
             );
         }
         ConfigValueSchema::Vec(vec_schema) => {
-            out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
+            let node_id = config_node_id(path);
+            out.push_str("<details id=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+            push_escaped(out, field_name);
+            out.push_str("\" data-breadcrumb-anchor=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\">\n<summary><code>");
             push_escaped(out, field_name);
             out.push_str("</code> <span class=\"meta\">list</span>");
             render_default_summary(out, field.default());
@@ -1131,7 +1283,14 @@ fn render_html_config_field_node(
             out.push_str("</div>\n</details>\n");
         }
         ConfigValueSchema::Enum(enum_schema) => {
-            out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
+            let node_id = config_node_id(path);
+            out.push_str("<details id=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+            push_escaped(out, field_name);
+            out.push_str("\" data-breadcrumb-anchor=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\">\n<summary><code>");
             push_escaped(out, field_name);
             out.push_str("</code> <span class=\"meta\">enum ");
             push_escaped(out, field.value().type_identifier());
@@ -1141,7 +1300,15 @@ fn render_html_config_field_node(
             render_config_field_docs(out, field);
             render_config_override_details(out, path, env_prefix);
             for (variant_name, variant) in enum_schema.variants() {
-                out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
+                let variant_path = join_path(path, variant_name);
+                let variant_id = config_node_id(&variant_path);
+                out.push_str("<details id=\"");
+                push_escaped(out, &variant_id);
+                out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+                push_escaped(out, variant_name);
+                out.push_str("\" data-breadcrumb-anchor=\"");
+                push_escaped(out, &variant_id);
+                out.push_str("\">\n<summary><code>");
                 push_escaped(out, variant_name);
                 out.push_str("</code> <span class=\"meta\">variant</span></summary>\n<div class=\"node-body\">\n");
                 if let Some(summary) = variant.docs().summary() {
@@ -1153,8 +1320,7 @@ fn render_html_config_field_node(
                     out.push_str("<p class=\"meta\">Unit variant.</p>\n");
                 }
                 for (variant_field_name, variant_field) in variant.fields() {
-                    let variant_path =
-                        join_path(&join_path(path, variant_name), variant_field_name);
+                    let variant_path = join_path(&variant_path, variant_field_name);
                     render_html_config_field_node(
                         out,
                         variant_field_name,
@@ -1206,7 +1372,14 @@ fn render_html_config_value_node(
             );
         }
         ConfigValueSchema::Enum(enum_schema) => {
-            out.push_str("<details class=\"schema-node search-item\">\n<summary><code>");
+            let node_id = config_node_id(path);
+            out.push_str("<details id=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\" class=\"schema-node search-item\" data-breadcrumb-label=\"");
+            push_escaped(out, name);
+            out.push_str("\" data-breadcrumb-anchor=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\">\n<summary><code>");
             push_escaped(out, name);
             out.push_str("</code> <span class=\"meta\">enum ");
             push_escaped(out, value.type_identifier());
@@ -1220,7 +1393,14 @@ fn render_html_config_value_node(
             out.push_str("</div>\n</details>\n");
         }
         ConfigValueSchema::Leaf(_) => {
-            out.push_str("<div class=\"schema-node search-item node-grid\"><div><code>");
+            let node_id = config_node_id(path);
+            out.push_str("<div id=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\" class=\"schema-node search-item node-grid\" data-breadcrumb-label=\"");
+            push_escaped(out, name);
+            out.push_str("\" data-breadcrumb-anchor=\"");
+            push_escaped(out, &node_id);
+            out.push_str("\"><div><code>");
             push_escaped(out, name);
             out.push_str("</code> <span class=\"meta\">");
             push_escaped(out, value.type_identifier());
@@ -1239,9 +1419,14 @@ fn render_html_config_leaf_node(
     field: &ConfigFieldSchema,
     env_prefix: Option<&str>,
 ) {
-    out.push_str(
-        "<div class=\"schema-node search-item config-field\"><div class=\"config-name\"><code>",
-    );
+    let node_id = config_node_id(path);
+    out.push_str("<div id=\"");
+    push_escaped(out, &node_id);
+    out.push_str("\" class=\"schema-node search-item config-field\" data-breadcrumb-label=\"");
+    push_escaped(out, field_name);
+    out.push_str("\" data-breadcrumb-anchor=\"");
+    push_escaped(out, &node_id);
+    out.push_str("\"><div class=\"config-name\"><code>");
     push_escaped(out, field_name);
     out.push_str("</code> <span class=\"meta\">");
     push_escaped(out, field.value().type_identifier());
@@ -1369,7 +1554,7 @@ fn join_path(prefix: &str, segment: &str) -> String {
 
 fn render_html_search_script(out: &mut String) {
     out.push_str(
-        r#"<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        r##"<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
 for (const source of document.querySelectorAll('[data-markdown-source]')) {
   const key = source.getAttribute('data-markdown-source');
@@ -1388,9 +1573,12 @@ const searchInput = document.querySelector('.search');
 const searchableRoot = document.querySelector('main');
 const intro = document.querySelector('[data-collapsible-intro]');
 const introToggle = document.querySelector('[data-intro-toggle]');
+const breadcrumbList = document.querySelector('[data-breadcrumbs]');
+const breadcrumbHome = document.querySelector('.topbar-title')?.textContent?.trim() || document.title || 'Home';
 let searchHits = [];
 let currentHit = -1;
 let revealingSearchHit = false;
+let breadcrumbFrame = 0;
 
 introToggle?.addEventListener('click', () => {
   intro?.classList.toggle('is-expanded');
@@ -1418,14 +1606,125 @@ searchInput?.addEventListener('keydown', event => {
   }
 });
 
+document.addEventListener('scroll', scheduleBreadcrumbUpdate, { passive: true });
+window.addEventListener('resize', scheduleBreadcrumbUpdate);
+breadcrumbList?.addEventListener('click', event => {
+  const link = event.target.closest('a[href^="#"]');
+  if (!link) {
+    return;
+  }
+  const id = decodeURIComponent(link.getAttribute('href').slice(1));
+  const target = document.getElementById(id);
+  if (!target) {
+    return;
+  }
+  event.preventDefault();
+  revealBreadcrumbTarget(target);
+  target.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+  history.replaceState(null, '', `#${encodeURIComponent(id)}`);
+});
+
 for (const details of document.querySelectorAll('details')) {
   details.addEventListener('toggle', () => {
+    scheduleBreadcrumbUpdate();
     if (!details.open || revealingSearchHit) {
       return;
     }
     window.setTimeout(() => {
       keepOpenedDetailsComfortable(details);
     }, 280);
+  });
+}
+
+scheduleBreadcrumbUpdate();
+
+function scheduleBreadcrumbUpdate() {
+  if (breadcrumbFrame) {
+    return;
+  }
+  breadcrumbFrame = requestAnimationFrame(() => {
+    breadcrumbFrame = 0;
+    updateBreadcrumbs();
+  });
+}
+
+function updateBreadcrumbs() {
+  if (!breadcrumbList) {
+    return;
+  }
+
+  const active = currentBreadcrumbTarget();
+  const trail = breadcrumbTrail(active);
+  breadcrumbList.replaceChildren();
+  appendBreadcrumbCrumb(breadcrumbList, breadcrumbHome, 'top');
+  for (const item of trail) {
+    appendBreadcrumbCrumb(
+      breadcrumbList,
+      item.getAttribute('data-breadcrumb-label'),
+      item.getAttribute('data-breadcrumb-anchor')
+    );
+  }
+}
+
+function currentBreadcrumbTarget() {
+  const items = [...document.querySelectorAll('[data-breadcrumb-label][data-breadcrumb-anchor]')]
+    .filter(item => item.getClientRects().length > 0);
+  if (items.length === 0) {
+    return null;
+  }
+
+  const topbarBottom = document.querySelector('.topbar')?.getBoundingClientRect().bottom || 0;
+  const activationLine = topbarBottom + 16;
+  let active = items[0];
+  for (const item of items) {
+    const rect = item.getBoundingClientRect();
+    if (rect.top <= activationLine) {
+      active = item;
+    } else {
+      break;
+    }
+  }
+  return active;
+}
+
+function breadcrumbTrail(active) {
+  const trail = [];
+  let node = active;
+  while (node) {
+    if (
+      node.matches?.('[data-breadcrumb-label][data-breadcrumb-anchor]') &&
+      node.getAttribute('data-breadcrumb-label') &&
+      node.getAttribute('data-breadcrumb-anchor')
+    ) {
+      trail.push(node);
+    }
+    node = node.parentElement?.closest('[data-breadcrumb-label][data-breadcrumb-anchor]');
+  }
+  return trail.reverse();
+}
+
+function appendBreadcrumbCrumb(list, label, anchor) {
+  if (!label || !anchor) {
+    return;
+  }
+  const li = document.createElement('li');
+  const link = document.createElement('a');
+  link.href = `#${anchor}`;
+  link.textContent = label;
+  li.append(link);
+  list.append(li);
+}
+
+function revealBreadcrumbTarget(target) {
+  revealingSearchHit = true;
+  let details = target.closest('details');
+  while (details) {
+    details.open = true;
+    details = details.parentElement?.closest('details');
+  }
+  requestAnimationFrame(() => {
+    revealingSearchHit = false;
+    scheduleBreadcrumbUpdate();
   });
 }
 
@@ -1606,7 +1905,7 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 </script>
-"#,
+"##,
     );
 }
 
@@ -2327,6 +2626,9 @@ mod tests {
         assert!(html.contains("&lt;INPUT&gt;"));
         assert!(html.contains("Input &lt;path&gt; to process"));
         assert!(html.contains("--[no-]verbose"));
+        assert!(html.contains("class=\"breadcrumbs\""));
+        assert!(html.contains("data-breadcrumbs"));
+        assert!(html.contains("function updateBreadcrumbs()"));
         assert!(html.contains("<nav class=\"side-nav\""));
         assert!(html.contains("max-height: calc(100vh - 92px); overflow-y: auto;"));
         assert!(html.contains("On This Page"));
@@ -2394,6 +2696,8 @@ mod tests {
         assert!(html.contains("Default <code class=\"value-token\">8080</code>"));
         assert!(!html.contains("config-schema-heading"));
         assert!(!html.contains("--settings.server.port &lt;U16&gt;</code></td><td>"));
+        assert!(html.contains("data-breadcrumb-label=\"Config fields for settings\""));
+        assert!(html.contains("data-breadcrumb-label=\"server\""));
         assert!(html.contains(".config-name code { white-space: normal;"));
         assert!(html.contains(
             ".override-grid { display: grid; grid-template-columns: max-content minmax(0, 1fr);"
@@ -2442,6 +2746,43 @@ mod tests {
         let html = generate_html_help::<Args>(&HelpConfig::default());
 
         assert!(html.contains("<p>Output path for the alignment JSONL (one object per line).</p>"));
+    }
+
+    #[test]
+    fn test_html_help_groups_flattened_config_fields() {
+        #[derive(Facet)]
+        struct Args {
+            #[facet(args::config)]
+            settings: Settings,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Settings {
+            /// Runtime tuning controls.
+            #[facet(flatten)]
+            runtime: Runtime,
+
+            /// Service host.
+            host: String,
+        }
+
+        #[derive(Facet)]
+        #[allow(dead_code)]
+        struct Runtime {
+            /// Worker count.
+            #[facet(default = 4)]
+            workers: usize,
+        }
+
+        let html = generate_html_help::<Args>(&HelpConfig::default());
+
+        assert!(html.contains("data-breadcrumb-label=\"runtime\""));
+        assert!(html.contains("<span class=\"meta\">group</span>"));
+        assert!(html.contains("<p>Runtime tuning controls.</p>"));
+        assert!(html.contains("data-breadcrumb-label=\"workers\""));
+        assert!(html.contains("data-copy=\"--settings.workers\""));
+        assert!(!html.contains("--settings.runtime.workers"));
     }
 
     #[test]

--- a/crates/figue/src/layers/cli.rs
+++ b/crates/figue/src/layers/cli.rs
@@ -179,6 +179,8 @@ struct ParentFlagLookup {
     parent_idx: usize,
     /// Effective name of the argument (owned to avoid borrow)
     effective_name: String,
+    /// ConfigValue path to insert into at that parent level.
+    insertion_path: Vec<String>,
     /// Whether this is a bool flag
     is_bool: bool,
     /// Whether this is a counted flag
@@ -391,7 +393,7 @@ impl<'a> ParseContext<'a> {
                 self.index += 1;
                 return;
             }
-            self.parse_flag_value(arg, effective_name, arg_schema, inline_value);
+            self.parse_flag_value(arg, arg_schema, inline_value);
         } else if let Some(lookup) = self.find_long_flag_in_parents(flag_name) {
             // Adoption agency: flag found in parent level, bubble up
             let target = InsertTarget::Parent(lookup.parent_idx);
@@ -403,20 +405,20 @@ impl<'a> ParseContext<'a> {
             self.parse_flag_value_simple(
                 arg,
                 target,
-                &lookup.effective_name,
+                &lookup.insertion_path,
                 lookup.is_bool,
                 None, // enum_variants not available for parent lookup
                 inline_value,
             );
         } else if let Some(negated_name) = flag_name.strip_prefix("no-") {
             // --no-<flag> syntax: negate a boolean flag
-            if let Some((effective_name, arg_schema)) = level.args().get(negated_name)
+            if let Some((_effective_name, arg_schema)) = level.args().get(negated_name)
                 && arg_schema.value().inner_if_option().is_bool()
             {
-                let effective_name = effective_name.to_string();
                 let prov = Provenance::cli(arg, "false".to_string());
-                self.insert_value(
-                    &effective_name,
+                self.insert_value_path_to(
+                    InsertTarget::Current,
+                    arg_schema.insertion_path(),
                     ConfigValue::Bool(Sourced {
                         value: false,
                         span: None,
@@ -429,11 +431,10 @@ impl<'a> ParseContext<'a> {
             {
                 // Adoption agency: boolean flag found in parent, negate it
                 let target = InsertTarget::Parent(lookup.parent_idx);
-                let effective_name = lookup.effective_name.clone();
                 let prov = Provenance::cli(arg, "false".to_string());
-                self.insert_value_to(
+                self.insert_value_path_to(
                     target,
-                    &effective_name,
+                    &lookup.insertion_path,
                     ConfigValue::Bool(Sourced {
                         value: false,
                         span: None,
@@ -603,25 +604,34 @@ impl<'a> ParseContext<'a> {
             });
 
             // Determine target and flag info
-            let (target, name, is_bool, is_counted) = if let Some((name, arg_schema)) = found {
-                let is_counted = matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
-                let is_bool = arg_schema
-                    .value()
-                    .inner_if_option()
-                    .is_bool_or_vec_of_bool();
-                (InsertTarget::Current, name.to_string(), is_bool, is_counted)
-            } else if let Some(lookup) = self.find_short_flag_in_parents(*ch) {
-                // Adoption agency: flag found in parent level
-                (
-                    InsertTarget::Parent(lookup.parent_idx),
-                    lookup.effective_name,
-                    lookup.is_bool,
-                    lookup.is_counted,
-                )
-            } else {
-                self.emit_error(format!("unknown flag: -{}", ch));
-                continue;
-            };
+            let (target, name, insertion_path, is_bool, is_counted) =
+                if let Some((name, arg_schema)) = found {
+                    let is_counted =
+                        matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
+                    let is_bool = arg_schema
+                        .value()
+                        .inner_if_option()
+                        .is_bool_or_vec_of_bool();
+                    (
+                        InsertTarget::Current,
+                        name.to_string(),
+                        arg_schema.insertion_path().to_vec(),
+                        is_bool,
+                        is_counted,
+                    )
+                } else if let Some(lookup) = self.find_short_flag_in_parents(*ch) {
+                    // Adoption agency: flag found in parent level
+                    (
+                        InsertTarget::Parent(lookup.parent_idx),
+                        lookup.effective_name,
+                        lookup.insertion_path,
+                        lookup.is_bool,
+                        lookup.is_counted,
+                    )
+                } else {
+                    self.emit_error(format!("unknown flag: -{}", ch));
+                    continue;
+                };
 
             if is_counted {
                 self.increment_counted_to(target, &name);
@@ -633,9 +643,9 @@ impl<'a> ParseContext<'a> {
             if is_bool {
                 // Bool flag: set to true
                 let prov = Provenance::cli(format!("-{}", ch), "true");
-                self.insert_value_to(
+                self.insert_value_path_to(
                     target,
-                    &name,
+                    &insertion_path,
                     ConfigValue::Bool(Sourced {
                         value: true,
                         span: None,
@@ -651,7 +661,7 @@ impl<'a> ParseContext<'a> {
                     let value_str = self.args[self.index];
                     let prov_arg = format!("-{}", ch);
                     let value = self.parse_value_string(value_str, &prov_arg, value_span);
-                    self.insert_value_to(target, &name, value);
+                    self.insert_value_path_to(target, &insertion_path, value);
                 } else {
                     // For short flags, we don't have easy access to enum variants
                     // Could be improved in the future
@@ -664,7 +674,7 @@ impl<'a> ParseContext<'a> {
                 let value_span = self.span_within_current(i + 1, rest.len());
                 let prov_arg = format!("-{}", ch);
                 let value = self.parse_value_string(&rest, &prov_arg, value_span);
-                self.insert_value_to(target, &name, value);
+                self.insert_value_path_to(target, &insertion_path, value);
                 break; // Consumed rest of chars
             }
         }
@@ -687,22 +697,30 @@ impl<'a> ParseContext<'a> {
         });
 
         // Determine target and flag info
-        let (target, name, is_bool, is_counted) = if let Some((name, arg_schema)) = found {
-            let is_counted = matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
-            let is_bool = arg_schema.value().inner_if_option().is_bool();
-            (InsertTarget::Current, name.to_string(), is_bool, is_counted)
-        } else if let Some(lookup) = self.find_short_flag_in_parents(ch) {
-            // Adoption agency: flag found in parent level
-            (
-                InsertTarget::Parent(lookup.parent_idx),
-                lookup.effective_name,
-                lookup.is_bool,
-                lookup.is_counted,
-            )
-        } else {
-            self.emit_error(format!("unknown flag: -{}", ch));
-            return;
-        };
+        let (target, name, insertion_path, is_bool, is_counted) =
+            if let Some((name, arg_schema)) = found {
+                let is_counted = matches!(arg_schema.kind(), ArgKind::Named { counted: true, .. });
+                let is_bool = arg_schema.value().inner_if_option().is_bool();
+                (
+                    InsertTarget::Current,
+                    name.to_string(),
+                    arg_schema.insertion_path().to_vec(),
+                    is_bool,
+                    is_counted,
+                )
+            } else if let Some(lookup) = self.find_short_flag_in_parents(ch) {
+                // Adoption agency: flag found in parent level
+                (
+                    InsertTarget::Parent(lookup.parent_idx),
+                    lookup.effective_name,
+                    lookup.insertion_path,
+                    lookup.is_bool,
+                    lookup.is_counted,
+                )
+            } else {
+                self.emit_error(format!("unknown flag: -{}", ch));
+                return;
+            };
 
         if is_counted {
             self.increment_counted_to(target, &name);
@@ -718,9 +736,9 @@ impl<'a> ParseContext<'a> {
                 "true" | "yes" | "1" | "on" | ""
             );
             let prov = Provenance::cli(&prov_arg, value.to_string());
-            self.insert_value_to(
+            self.insert_value_path_to(
                 target,
-                &name,
+                &insertion_path,
                 ConfigValue::Bool(Sourced {
                     value,
                     span: None,
@@ -731,23 +749,17 @@ impl<'a> ParseContext<'a> {
             // Value starts after the '=' which is at position 2 (after -k)
             let value_span = self.span_within_current(3, value_str.len());
             let value = self.parse_value_string(value_str, &prov_arg, value_span);
-            self.insert_value_to(target, &name, value);
+            self.insert_value_path_to(target, &insertion_path, value);
         }
     }
 
-    fn parse_flag_value(
-        &mut self,
-        arg: &str,
-        name: &str,
-        schema: &ArgSchema,
-        inline_value: Option<&str>,
-    ) {
+    fn parse_flag_value(&mut self, arg: &str, schema: &ArgSchema, inline_value: Option<&str>) {
         let is_bool = schema.value().inner_if_option().is_bool();
         let enum_variants = schema.value().inner_if_option().enum_variants();
         self.parse_flag_value_simple(
             arg,
             InsertTarget::Current,
-            name,
+            schema.insertion_path(),
             is_bool,
             enum_variants,
             inline_value,
@@ -759,7 +771,7 @@ impl<'a> ParseContext<'a> {
         &mut self,
         arg: &str,
         target: InsertTarget,
-        name: &str,
+        insertion_path: &[String],
         is_bool: bool,
         enum_variants: Option<&[String]>,
         inline_value: Option<&str>,
@@ -773,9 +785,9 @@ impl<'a> ParseContext<'a> {
                 true
             };
             let prov = Provenance::cli(arg, value.to_string());
-            self.insert_value_to(
+            self.insert_value_path_to(
                 target,
-                name,
+                insertion_path,
                 ConfigValue::Bool(Sourced {
                     value,
                     span: None,
@@ -786,6 +798,7 @@ impl<'a> ParseContext<'a> {
         } else {
             // Non-bool: need a value
             let flag_span = self.current_span();
+            let name = insertion_path.last().map(String::as_str).unwrap_or("");
 
             // Check up-front whether this is the special completions field,
             // which is allowed to omit its value (triggering auto-detection).
@@ -812,9 +825,9 @@ impl<'a> ParseContext<'a> {
                 if is_completions_field && (at_end || next_looks_like_flag) {
                     // No shell specified — store sentinel for auto-detection.
                     let prov = Provenance::cli(arg, "auto");
-                    self.insert_value_to(
+                    self.insert_value_path_to(
                         target,
-                        name,
+                        insertion_path,
                         ConfigValue::String(Sourced {
                             value: "auto".to_string(),
                             span: None,
@@ -843,7 +856,7 @@ impl<'a> ParseContext<'a> {
 
             let prov_arg = arg.split('=').next().unwrap_or(arg);
             let value = self.parse_value_string(value_str, prov_arg, value_span);
-            self.insert_value_to(target, name, value);
+            self.insert_value_path_to(target, insertion_path, value);
         }
     }
 
@@ -1106,6 +1119,7 @@ impl<'a> ParseContext<'a> {
                 return Some(ParentFlagLookup {
                     parent_idx: idx,
                     effective_name: effective_name.to_string(),
+                    insertion_path: arg_schema.insertion_path().to_vec(),
                     is_bool,
                     is_counted,
                 });
@@ -1128,6 +1142,7 @@ impl<'a> ParseContext<'a> {
                     return Some(ParentFlagLookup {
                         parent_idx: idx,
                         effective_name: name.to_string(),
+                        insertion_path: schema.insertion_path().to_vec(),
                         is_bool,
                         is_counted,
                     });
@@ -1158,19 +1173,19 @@ impl<'a> ParseContext<'a> {
         let arg = self.args[self.index];
 
         // Find the next unset positional argument
-        for (name, schema) in level.args() {
+        for (_name, schema) in level.args() {
             if !matches!(schema.kind(), ArgKind::Positional) {
                 continue;
             }
 
             // Check if already set (unless it's multiple/list)
-            if self.has_value(name) && !schema.multiple() {
+            if self.has_value_path(schema.insertion_path()) && !schema.multiple() {
                 continue;
             }
 
             let value_span = self.current_span();
             let value = self.parse_value_string(arg, arg, value_span);
-            self.insert_value(name, value);
+            self.insert_value_path_to(InsertTarget::Current, schema.insertion_path(), value);
             self.index += 1;
             return true;
         }
@@ -1195,20 +1210,43 @@ impl<'a> ParseContext<'a> {
         })
     }
 
-    /// Insert a value at the arg's effective name (flat, not nested).
-    /// For repeated flags (Vec fields), accumulates values into an array.
-    fn insert_value(&mut self, name: &str, value: ConfigValue) {
-        self.insert_value_to(InsertTarget::Current, name, value);
-    }
-
-    /// Insert a value to a specific target (current level or parent level).
-    fn insert_value_to(&mut self, target: InsertTarget, name: &str, value: ConfigValue) {
+    /// Insert a value to a specific target and ConfigValue path.
+    fn insert_value_path_to(&mut self, target: InsertTarget, path: &[String], value: ConfigValue) {
         let result_map = match target {
             InsertTarget::Current => &mut self.result,
             InsertTarget::Parent(idx) => &mut self.parent_stack[idx].result,
         };
 
-        match result_map.entry(name.to_string()) {
+        Self::insert_value_at_path(result_map, path, value);
+    }
+
+    fn insert_value_at_path(
+        result_map: &mut IndexMap<String, ConfigValue, RandomState>,
+        path: &[String],
+        value: ConfigValue,
+    ) {
+        let Some((head, tail)) = path.split_first() else {
+            return;
+        };
+
+        if !tail.is_empty() {
+            let entry = result_map
+                .entry(head.clone())
+                .or_insert_with(|| ConfigValue::Object(Sourced::new(IndexMap::default())));
+            match entry {
+                ConfigValue::Object(sourced) => {
+                    Self::insert_value_at_path(&mut sourced.value, tail, value);
+                }
+                existing => {
+                    let mut nested = IndexMap::default();
+                    Self::insert_value_at_path(&mut nested, tail, value);
+                    *existing = ConfigValue::Object(Sourced::new(nested));
+                }
+            }
+            return;
+        }
+
+        match result_map.entry(head.clone()) {
             indexmap::map::Entry::Vacant(entry) => {
                 entry.insert(value);
             }
@@ -1235,9 +1273,19 @@ impl<'a> ParseContext<'a> {
         }
     }
 
-    /// Check if a value exists at the given name.
-    fn has_value(&self, name: &str) -> bool {
-        self.result.contains_key(name)
+    /// Check if a value exists at the given insertion path.
+    fn has_value_path(&self, path: &[String]) -> bool {
+        let Some((head, tail)) = path.split_first() else {
+            return false;
+        };
+        let mut current = self.result.get(head);
+        for segment in tail {
+            current = match current {
+                Some(ConfigValue::Object(sourced)) => sourced.value.get(segment),
+                _ => return false,
+            };
+        }
+        current.is_some()
     }
 
     fn increment_counted(&mut self, name: &str) {
@@ -1301,7 +1349,12 @@ impl<'a> ParseContext<'a> {
 
             // Merge builder's value into result under the config field name
             if let Some(config_value) = builder_output.value {
-                self.result.insert(config_field_name.clone(), config_value);
+                let value = if let Some(existing) = self.result.shift_remove(&config_field_name) {
+                    crate::merge::merge(existing, config_value, &config_field_name).value
+                } else {
+                    config_value
+                };
+                self.result.insert(config_field_name.clone(), value);
             }
 
             if multiple_config_roots {
@@ -1764,6 +1817,29 @@ mod tests {
         config: ServerConfigWithFlattenCli,
     }
 
+    #[derive(Facet)]
+    struct FlatRunConfigRootCli {
+        tui: bool,
+        model: String,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithFlattenedConfigRootCli {
+        #[facet(args::config)]
+        #[facet(flatten)]
+        run: FlatRunConfigRootCli,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithConflictingFlattenedConfigRootCli {
+        #[facet(args::named)]
+        model: String,
+
+        #[facet(args::config)]
+        #[facet(flatten)]
+        run: FlatRunConfigRootCli,
+    }
+
     #[test]
     fn test_config_override_with_flattened_struct() {
         // Flattened fields are accessed directly without the wrapper field name.
@@ -1842,6 +1918,44 @@ mod tests {
         assert_diagnostic_contains::<ArgsWithFlattenedConfigCli>(
             &["--no-config.port"],
             "unknown flag",
+        );
+    }
+
+    #[test]
+    fn test_flattened_config_root_exposes_fields_as_cli_flags() {
+        assert_parses_to::<ArgsWithFlattenedConfigRootCli>(
+            &["--tui", "--model", "1.7b"],
+            cv::object([(
+                "run",
+                cv::object([
+                    ("tui", cv::bool(true, "--tui")),
+                    ("model", cv::string("1.7b", "--model")),
+                ]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_flattened_config_root_exposes_no_prefix_for_bool() {
+        assert_parses_to::<ArgsWithFlattenedConfigRootCli>(
+            &["--no-tui", "--model", "1.7b"],
+            cv::object([(
+                "run",
+                cv::object([
+                    ("tui", cv::bool(false, "--no-tui")),
+                    ("model", cv::string("1.7b", "--model")),
+                ]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_flattened_config_root_rejects_cli_flag_conflicts() {
+        let err = Schema::from_shape(ArgsWithConflictingFlattenedConfigRootCli::SHAPE)
+            .expect_err("conflicting flattened config root should fail schema construction");
+        assert!(
+            err.to_string().contains("duplicate flag `--model`"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/figue/src/layers/cli.rs
+++ b/crates/figue/src/layers/cli.rs
@@ -38,7 +38,9 @@ use indexmap::IndexMap;
 use crate::config_value::{ConfigValue, EnumValue, Sourced};
 use crate::driver::{Diagnostic, LayerOutput, Severity};
 use crate::provenance::Provenance;
-use crate::schema::{ArgKind, ArgLevelSchema, ArgSchema, Schema, Subcommand};
+use crate::schema::{
+    ArgKind, ArgLevelSchema, ArgSchema, ConfigStructSchema, ConfigValueSchema, Schema, Subcommand,
+};
 use crate::value_builder::{LeafValue, ValueBuilder};
 
 // ============================================================================
@@ -181,6 +183,20 @@ struct ParentFlagLookup {
     is_bool: bool,
     /// Whether this is a counted flag
     is_counted: bool,
+}
+
+/// Parsed metadata for a dotted config override flag.
+struct ConfigOverrideTarget<'a> {
+    /// Flag name without the leading `--` and without a leading `no-`.
+    flag_name: &'a str,
+    /// Kebab-case config root name used on the CLI.
+    cli_root: String,
+    /// Effective config field name in the schema.
+    config_field_name: String,
+    /// Whether the flag used `--no-...`.
+    negated: bool,
+    /// Whether the target config value is a boolean.
+    is_bool: bool,
 }
 
 /// Parser context holding state during CLI parsing.
@@ -335,17 +351,20 @@ impl<'a> ParseContext<'a> {
         for config_schema in self.schema.configs() {
             if let Some(config_field_name) = config_schema.field_name() {
                 let cli_root = config_field_name.to_kebab_case();
-                if flag_name.starts_with(&cli_root)
-                    && flag_name.len() > cli_root.len()
-                    && flag_name.as_bytes()[cli_root.len()] == b'.'
+                if let Some((override_flag_name, negated)) =
+                    Self::config_override_flag_name(flag_name, &cli_root)
                 {
-                    self.parse_config_override(
-                        arg,
-                        flag_name,
-                        inline_value,
-                        &cli_root,
-                        config_field_name,
-                    );
+                    let path_str = &override_flag_name[cli_root.len() + 1..];
+                    let parts: Vec<&str> = path_str.split('.').collect();
+                    let is_bool = Self::config_path_is_bool(config_schema, &parts);
+                    let target = ConfigOverrideTarget {
+                        flag_name: override_flag_name,
+                        cli_root: cli_root.to_string(),
+                        config_field_name: config_field_name.to_string(),
+                        negated,
+                        is_bool,
+                    };
+                    self.parse_config_override(arg, inline_value, target);
                     return;
                 }
             }
@@ -455,6 +474,101 @@ impl<'a> ParseContext<'a> {
             let suggestion = crate::suggest::suggest_flag(flag_name, all_flags);
             self.emit_error(format!("unknown flag: --{}{}", flag_name, suggestion));
             self.index += 1;
+        }
+    }
+
+    fn config_override_flag_name<'b>(
+        flag_name: &'b str,
+        cli_root: &str,
+    ) -> Option<(&'b str, bool)> {
+        if Self::is_config_override_flag(flag_name, cli_root) {
+            Some((flag_name, false))
+        } else if let Some(negated_name) = flag_name.strip_prefix("no-")
+            && Self::is_config_override_flag(negated_name, cli_root)
+        {
+            Some((negated_name, true))
+        } else {
+            None
+        }
+    }
+
+    fn is_config_override_flag(flag_name: &str, cli_root: &str) -> bool {
+        flag_name.starts_with(cli_root)
+            && flag_name.len() > cli_root.len()
+            && flag_name.as_bytes()[cli_root.len()] == b'.'
+    }
+
+    fn config_path_is_bool(config_schema: &ConfigStructSchema, path: &[&str]) -> bool {
+        Self::resolve_config_value_schema(config_schema, path)
+            .is_some_and(ConfigValueSchema::is_bool)
+    }
+
+    fn resolve_config_value_schema<'s>(
+        config_schema: &'s ConfigStructSchema,
+        path: &[&str],
+    ) -> Option<&'s ConfigValueSchema> {
+        if path.is_empty() {
+            return None;
+        }
+
+        let segment = path[0];
+        let (_, field_schema) = config_schema
+            .fields()
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(segment) || key.to_kebab_case() == segment)?;
+
+        if path.len() == 1 {
+            return Some(field_schema.value());
+        }
+
+        Self::resolve_nested_config_value_schema(field_schema.value(), &path[1..])
+    }
+
+    fn resolve_nested_config_value_schema<'s>(
+        value_schema: &'s ConfigValueSchema,
+        path: &[&str],
+    ) -> Option<&'s ConfigValueSchema> {
+        if path.is_empty() {
+            return Some(value_schema);
+        }
+
+        match value_schema {
+            ConfigValueSchema::Option { value, .. } => {
+                Self::resolve_nested_config_value_schema(value, path)
+            }
+            ConfigValueSchema::Struct(struct_schema) => {
+                Self::resolve_config_value_schema(struct_schema, path)
+            }
+            ConfigValueSchema::Enum(enum_schema) => {
+                let segment = path[0];
+                let (_, variant_schema) = enum_schema.variants().iter().find(|(key, _)| {
+                    key.eq_ignore_ascii_case(segment) || key.to_kebab_case() == segment
+                })?;
+
+                if path.len() == 1 {
+                    return None;
+                }
+
+                let field_segment = path[1];
+                let (_, field_schema) = variant_schema.fields().iter().find(|(key, _)| {
+                    key.eq_ignore_ascii_case(field_segment) || key.to_kebab_case() == field_segment
+                })?;
+
+                if path.len() == 2 {
+                    Some(field_schema.value())
+                } else {
+                    Self::resolve_nested_config_value_schema(field_schema.value(), &path[2..])
+                }
+            }
+            ConfigValueSchema::Vec(vec_schema) => {
+                path[0].parse::<usize>().ok()?;
+                if path.len() == 1 {
+                    Some(vec_schema.element())
+                } else {
+                    Self::resolve_nested_config_value_schema(vec_schema.element(), &path[1..])
+                }
+            }
+            ConfigValueSchema::Leaf(_) => None,
         }
     }
 
@@ -735,21 +849,71 @@ impl<'a> ParseContext<'a> {
 
     fn parse_config_override(
         &mut self,
-        _arg: &str,
-        flag_name: &str,
+        arg: &str,
         inline_value: Option<&str>,
-        cli_root: &str,
-        config_field_name: &str,
+        target: ConfigOverrideTarget<'_>,
     ) {
         // Extract the path after "config."
-        let path_str = &flag_name[cli_root.len() + 1..];
+        let path_str = &target.flag_name[target.cli_root.len() + 1..];
         let parts: Vec<&str> = path_str.split('.').collect();
 
         // Get the value
         let flag_span = self.current_span(); // Save span before incrementing
+        if target.negated {
+            if !target.is_bool {
+                self.emit_error(format!("unknown flag: {}", arg));
+                self.index += 1;
+                return;
+            }
+
+            let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
+            let provenance = Provenance::cli(arg, "false");
+            self.config_builders
+                .get_mut(&target.config_field_name)
+                .expect("config_builder must exist when parsing config overrides")
+                .set(&path, LeafValue::Bool(false), None, provenance);
+            self.index += 1;
+            return;
+        }
+
+        if target.is_bool {
+            let mut value = true;
+            let mut provenance_value = String::from("true");
+            let mut value_span = None;
+
+            if let Some(v) = inline_value {
+                value = Self::parse_bool_literal(v).unwrap_or(false);
+                provenance_value = v.to_string();
+                let eq_pos = target.flag_name.len() + 3 + 1; // "--" + flag_name + "="
+                value_span = Some(self.span_within_current(eq_pos, v.len()));
+                self.index += 1;
+            } else {
+                self.index += 1;
+                if self.index < self.args.len()
+                    && let Some(parsed) = Self::parse_bool_literal(self.args[self.index])
+                {
+                    let v = self.args[self.index];
+                    value = parsed;
+                    provenance_value = v.to_string();
+                    value_span = Some(self.current_span());
+                    self.index += 1;
+                }
+            }
+
+            let prov_arg = format!("--{}", target.flag_name);
+            let provenance = Provenance::cli(&prov_arg, provenance_value);
+            let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
+
+            self.config_builders
+                .get_mut(&target.config_field_name)
+                .expect("config_builder must exist when parsing config overrides")
+                .set(&path, LeafValue::Bool(value), value_span, provenance);
+            return;
+        }
+
         let (value_str, value_span) = if let Some(v) = inline_value {
             // --config.key=value: value starts after the '='
-            let eq_pos = flag_name.len() + 3 + 1; // "--" + flag_name + "="
+            let eq_pos = target.flag_name.len() + 3 + 1; // "--" + flag_name + "="
             let span = self.span_within_current(eq_pos, v.len());
             self.index += 1;
             (v, span)
@@ -761,20 +925,31 @@ impl<'a> ParseContext<'a> {
                 self.index += 1;
                 (v, span)
             } else {
-                self.emit_error_at(format!("flag --{} requires a value", flag_name), flag_span);
+                self.emit_error_at(
+                    format!("flag --{} requires a value", target.flag_name),
+                    flag_span,
+                );
                 return;
             }
         };
 
-        let prov_arg = format!("--{}", flag_name);
+        let prov_arg = format!("--{}", target.flag_name);
         let provenance = Provenance::cli(&prov_arg, value_str);
         let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
         let leaf_value = LeafValue::String(value_str.to_string());
 
         self.config_builders
-            .get_mut(config_field_name)
+            .get_mut(&target.config_field_name)
             .expect("config_builder must exist when parsing config overrides")
             .set(&path, leaf_value, Some(value_span), provenance);
+    }
+
+    fn parse_bool_literal(value: &str) -> Option<bool> {
+        match value.to_lowercase().as_str() {
+            "true" | "yes" | "1" | "on" | "" => Some(true),
+            "false" | "no" | "0" | "off" => Some(false),
+            _ => None,
+        }
     }
 
     /// Parse the config file path flag (e.g., `--config /path/to/file.json`).
@@ -1612,9 +1787,61 @@ mod tests {
                 "config",
                 cv::object([
                     ("port", cv::string("8080", "--config.port")),
-                    ("debug", cv::string("true", "--config.debug")),
+                    ("debug", cv::bool(true, "--config.debug")),
                 ]),
             )]),
+        );
+    }
+
+    #[test]
+    fn test_config_bool_override_allows_bare_flag() {
+        assert_parses_to::<ArgsWithFlattenedConfigCli>(
+            &["--config.debug"],
+            cv::object([(
+                "config",
+                cv::object([("debug", cv::bool(true, "--config.debug"))]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_config_bool_override_allows_no_prefix() {
+        assert_parses_to::<ArgsWithFlattenedConfigCli>(
+            &["--no-config.debug"],
+            cv::object([(
+                "config",
+                cv::object([("debug", cv::bool(false, "--no-config.debug"))]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_config_bool_override_allows_inline_false() {
+        assert_parses_to::<ArgsWithFlattenedConfigCli>(
+            &["--config.debug=false"],
+            cv::object([(
+                "config",
+                cv::object([("debug", cv::bool(false, "--config.debug"))]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_config_bool_override_allows_separate_false() {
+        assert_parses_to::<ArgsWithFlattenedConfigCli>(
+            &["--config.debug", "false"],
+            cv::object([(
+                "config",
+                cv::object([("debug", cv::bool(false, "--config.debug"))]),
+            )]),
+        );
+    }
+
+    #[test]
+    fn test_no_prefix_config_override_rejects_non_bool() {
+        assert_diagnostic_contains::<ArgsWithFlattenedConfigCli>(
+            &["--no-config.port"],
+            "unknown flag",
         );
     }
 

--- a/crates/figue/src/layers/cli.rs
+++ b/crates/figue/src/layers/cli.rs
@@ -206,9 +206,8 @@ struct ParseContext<'a> {
     parent_stack: Vec<ParentLevel<'a>>,
     /// ValueBuilders for config overrides (--config.foo.bar style), keyed by config root field.
     config_builders: IndexMap<String, ValueBuilder<'a>, RandomState>,
-    /// Config file path captured from `--<config-field-name> <path>`.
-    /// E.g., if the config field is named "config", this captures `--config /path/to/file.json`.
-    config_file_path: Option<camino::Utf8PathBuf>,
+    /// Config file paths captured by config root.
+    config_file_paths: IndexMap<String, camino::Utf8PathBuf, RandomState>,
 }
 
 impl<'a> ParseContext<'a> {
@@ -247,7 +246,7 @@ impl<'a> ParseContext<'a> {
             arg_offsets,
             parent_stack: Vec::new(),
             config_builders,
-            config_file_path: None,
+            config_file_paths: IndexMap::default(),
         }
     }
 
@@ -358,7 +357,7 @@ impl<'a> ParseContext<'a> {
             if let Some(config_field_name) = config_schema.field_name()
                 && flag_name == config_field_name.to_kebab_case()
             {
-                self.parse_config_file_path(arg, inline_value);
+                self.parse_config_file_path(arg, inline_value, config_field_name);
                 return;
             }
         }
@@ -784,7 +783,12 @@ impl<'a> ParseContext<'a> {
     /// - Field `config: ServerConfig` -> `--config <path>`
     /// - Field `settings: ServerConfig` -> `--settings <path>`
     /// - Field `#[facet(rename = "cfg")] config: ServerConfig` -> `--cfg <path>`
-    fn parse_config_file_path(&mut self, arg: &str, inline_value: Option<&str>) {
+    fn parse_config_file_path(
+        &mut self,
+        arg: &str,
+        inline_value: Option<&str>,
+        config_field_name: &str,
+    ) {
         let flag_span = self.current_span();
 
         let path_str = if let Some(v) = inline_value {
@@ -804,7 +808,9 @@ impl<'a> ParseContext<'a> {
             }
         };
 
-        self.config_file_path = Some(camino::Utf8PathBuf::from(path_str));
+        let path = camino::Utf8PathBuf::from(path_str);
+        self.config_file_paths
+            .insert(config_field_name.to_string(), path);
     }
 
     fn try_parse_subcommand(&mut self, level: &'a ArgLevelSchema) -> bool {
@@ -1151,7 +1157,7 @@ impl<'a> ParseContext<'a> {
             unused_keys,
             diagnostics,
             source_text: None,
-            config_file_path: self.config_file_path,
+            config_file_paths: self.config_file_paths,
         }
     }
 }

--- a/crates/figue/src/layers/env.rs
+++ b/crates/figue/src/layers/env.rs
@@ -240,7 +240,7 @@ pub fn parse_env(schema: &Schema, env_config: &EnvConfig, source: &dyn EnvSource
         unused_keys,
         diagnostics,
         source_text: None,
-        config_file_path: None,
+        config_file_paths: IndexMap::default(),
     };
 
     // Assign spans to env-sourced values and build the virtual source document
@@ -402,7 +402,7 @@ fn parse_env_no_config(env_config: &EnvConfig, source: &dyn EnvSource) -> LayerO
         unused_keys,
         diagnostics: Vec::new(),
         source_text: None,
-        config_file_path: None,
+        config_file_paths: IndexMap::default(),
     }
 }
 

--- a/crates/figue/src/layers/file.rs
+++ b/crates/figue/src/layers/file.rs
@@ -389,28 +389,7 @@ impl<'a> FileParseContext<'a> {
                     self.early_diagnostics,
                 )
             } else if let Some(ref parsed) = self.value {
-                if self.schema.configs().len() == 1 {
-                    let config_schema = &self.schema.configs()[0];
-                    // Create a ValueBuilder and import the parsed tree
-                    let mut builder = ValueBuilder::new(config_schema);
-                    builder.import_tree(parsed);
-
-                    // Unknown keys are tracked in unused_keys by the builder.
-                    // In strict mode, they'll be reported by the driver alongside the config dump.
-
-                    // Get the output from the builder
-                    let mut output = builder
-                        .into_output_with_value(self.value.clone(), config_schema.field_name());
-
-                    // Prepend any early diagnostics (file read errors, etc.)
-                    let mut all_diagnostics = self.early_diagnostics;
-                    all_diagnostics.append(&mut output.diagnostics);
-                    output.diagnostics = all_diagnostics;
-
-                    output
-                } else {
-                    Self::multi_config_output(self.schema, parsed, self.early_diagnostics)
-                }
+                Self::multi_config_output(self.schema, parsed, self.early_diagnostics)
             } else {
                 // No parsed value - return early diagnostics only
                 LayerOutput {
@@ -680,7 +659,7 @@ mod tests {
 
     #[test]
     fn test_parse_simple_json() {
-        let file = create_temp_json(r#"{"port": 8080, "host": "localhost"}"#);
+        let file = create_temp_json(r#"{"config": {"port": 8080, "host": "localhost"}}"#);
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithConfig::SHAPE).unwrap();
@@ -702,7 +681,7 @@ mod tests {
     #[test]
     fn test_parse_nested_json() {
         let file = create_temp_json(
-            r#"{"port": 8080, "smtp": {"host": "mail.example.com", "connection_timeout": 30}}"#,
+            r#"{"settings": {"port": 8080, "smtp": {"host": "mail.example.com", "connection_timeout": 30}}}"#,
         );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
@@ -757,7 +736,7 @@ mod tests {
 
     #[test]
     fn test_default_paths_tried_in_order() {
-        let file = create_temp_json(r#"{"port": 9000, "host": "default"}"#);
+        let file = create_temp_json(r#"{"config": {"port": 9000, "host": "default"}}"#);
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithConfig::SHAPE).unwrap();
@@ -790,7 +769,9 @@ mod tests {
 
     #[test]
     fn test_unknown_key_tracked() {
-        let file = create_temp_json(r#"{"port": 8080, "host": "localhost", "unknown_field": 123}"#);
+        let file = create_temp_json(
+            r#"{"config": {"port": 8080, "host": "localhost", "unknown_field": 123}}"#,
+        );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithConfig::SHAPE).unwrap();
@@ -816,7 +797,9 @@ mod tests {
     fn test_unknown_key_tracked_in_strict_mode() {
         // In strict mode, unknown keys are tracked in unused_keys.
         // The driver will report them alongside the config dump (not as early errors).
-        let file = create_temp_json(r#"{"port": 8080, "host": "localhost", "unknown_field": 123}"#);
+        let file = create_temp_json(
+            r#"{"config": {"port": 8080, "host": "localhost", "unknown_field": 123}}"#,
+        );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithConfig::SHAPE).unwrap();
@@ -834,7 +817,7 @@ mod tests {
                 .output
                 .unused_keys
                 .iter()
-                .any(|uk| uk.key.join(".") == "unknown_field"),
+                .any(|uk| uk.key.join(".") == "config.unknown_field"),
             "unused_keys should contain 'unknown_field': {:?}",
             result.output.unused_keys
         );
@@ -859,7 +842,7 @@ mod tests {
 
     #[test]
     fn test_file_provenance() {
-        let file = create_temp_json(r#"{"port": 8080, "host": "localhost"}"#);
+        let file = create_temp_json(r#"{"config": {"port": 8080, "host": "localhost"}}"#);
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithConfig::SHAPE).unwrap();
@@ -933,7 +916,9 @@ mod tests {
     fn test_flatten_config_parses_flat_json() {
         // JSON file has FLAT structure - flattened fields appear at the current level
         // NOT nested under "common"
-        let file = create_temp_json(r#"{"name": "myapp", "log_level": "debug", "debug": true}"#);
+        let file = create_temp_json(
+            r#"{"config": {"name": "myapp", "log_level": "debug", "debug": true}}"#,
+        );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
         let schema = Schema::from_shape(ArgsWithFlattenedConfig::SHAPE).unwrap();
@@ -971,7 +956,7 @@ mod tests {
         // JSON with nested "common" should be rejected - "common" is not a valid key
         // because it's flattened (its fields are hoisted to the parent level)
         let file = create_temp_json(
-            r#"{"name": "myapp", "common": {"log_level": "debug", "debug": true}}"#,
+            r#"{"config": {"name": "myapp", "common": {"log_level": "debug", "debug": true}}}"#,
         );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
@@ -1030,11 +1015,13 @@ mod tests {
         // flattened common and database. So ALL fields appear at the top level.
         let file = create_temp_json(
             r#"{
-                "app_name": "super-app",
-                "log_level": "info",
-                "debug": false,
-                "host": "db.example.com",
-                "port": 5432
+                "config": {
+                    "app_name": "super-app",
+                    "log_level": "info",
+                    "debug": false,
+                    "host": "db.example.com",
+                    "port": 5432
+                }
             }"#,
         );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
@@ -1078,7 +1065,7 @@ mod tests {
     fn test_flatten_config_unknown_key_detection() {
         // JSON with an unknown key at the flattened level
         let file = create_temp_json(
-            r#"{"name": "myapp", "log_level": "debug", "debug": true, "unknown_field": 123}"#,
+            r#"{"config": {"name": "myapp", "log_level": "debug", "debug": true, "unknown_field": 123}}"#,
         );
         let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
 
@@ -1130,8 +1117,10 @@ mod tests {
     fn test_enum_valid_variant_no_warning() {
         // Valid variant should not produce a warning
         let schema = Schema::from_shape(ArgsWithEnumConfig::SHAPE).unwrap();
-        let config =
-            FileConfig::new().content(r#"{"log_level": "Debug", "port": 8080}"#, "config.json");
+        let config = FileConfig::new().content(
+            r#"{"config": {"log_level": "Debug", "port": 8080}}"#,
+            "config.json",
+        );
 
         let result = parse_file(&schema, &config);
 
@@ -1146,8 +1135,10 @@ mod tests {
     fn test_enum_invalid_variant_produces_warning() {
         // Invalid variant should produce a warning with helpful message
         let schema = Schema::from_shape(ArgsWithEnumConfig::SHAPE).unwrap();
-        let config =
-            FileConfig::new().content(r#"{"log_level": "Debugg", "port": 8080}"#, "config.json"); // typo
+        let config = FileConfig::new().content(
+            r#"{"config": {"log_level": "Debugg", "port": 8080}}"#,
+            "config.json",
+        ); // typo
 
         let result = parse_file(&schema, &config);
 
@@ -1189,7 +1180,8 @@ mod tests {
     fn test_optional_enum_validation() {
         // Optional enum should also be validated
         let schema = Schema::from_shape(ArgsWithOptionalEnumConfig::SHAPE).unwrap();
-        let config = FileConfig::new().content(r#"{"log_level": "invalid"}"#, "config.json");
+        let config =
+            FileConfig::new().content(r#"{"config": {"log_level": "invalid"}}"#, "config.json");
 
         let result = parse_file(&schema, &config);
 
@@ -1220,8 +1212,10 @@ mod tests {
     fn test_nested_enum_validation() {
         // Enum in nested struct should be validated
         let schema = Schema::from_shape(ArgsWithNestedEnumConfig::SHAPE).unwrap();
-        let config =
-            FileConfig::new().content(r#"{"logging": {"level": "unknown"}}"#, "config.json");
+        let config = FileConfig::new().content(
+            r#"{"config": {"logging": {"level": "unknown"}}}"#,
+            "config.json",
+        );
 
         let result = parse_file(&schema, &config);
 

--- a/crates/figue/src/layers/file.rs
+++ b/crates/figue/src/layers/file.rs
@@ -128,8 +128,11 @@ impl FormatRegistry {
 
 /// Configuration for config file parsing.
 pub struct FileConfig {
-    /// Explicit path provided via CLI (e.g., --config path.json).
+    /// Explicit global config path provided through the builder API.
     pub explicit_path: Option<Utf8PathBuf>,
+
+    /// Explicit paths provided via CLI, keyed by config root field name.
+    pub explicit_paths_by_root: IndexMap<String, Utf8PathBuf>,
 
     /// Default paths to check if no explicit path is provided.
     pub default_paths: Vec<Utf8PathBuf>,
@@ -150,6 +153,7 @@ impl Default for FileConfig {
     fn default() -> Self {
         Self {
             explicit_path: None,
+            explicit_paths_by_root: IndexMap::default(),
             default_paths: Vec::new(),
             registry: FormatRegistry::with_defaults(),
             strict: false,
@@ -233,6 +237,8 @@ struct FileParseContext<'a> {
     config: &'a FileConfig,
     /// Parsed config value (if successful)
     value: Option<ConfigValue>,
+    /// Parsed config values that were explicitly targeted at config roots.
+    targeted_values: IndexMap<String, ConfigValue>,
     /// Diagnostics collected before ValueBuilder takes over
     early_diagnostics: Vec<Diagnostic>,
     /// File resolution tracking
@@ -245,12 +251,18 @@ impl<'a> FileParseContext<'a> {
             schema,
             config,
             value: None,
+            targeted_values: IndexMap::default(),
             early_diagnostics: Vec::new(),
             resolution: FileResolution::new(),
         }
     }
 
     fn parse(&mut self) {
+        if self.config.inline_content.is_none() && !self.config.explicit_paths_by_root.is_empty() {
+            self.parse_targeted_paths();
+            return;
+        }
+
         // Check for inline content first (used for testing)
         let (path, contents) = if let Some((content, filename)) = &self.config.inline_content {
             let path = Utf8PathBuf::from(filename);
@@ -285,6 +297,39 @@ impl<'a> FileParseContext<'a> {
         };
 
         self.value = Some(parsed);
+    }
+
+    fn parse_targeted_paths(&mut self) {
+        self.resolution
+            .mark_defaults_not_tried(&self.config.default_paths);
+
+        for (field_name, path) in &self.config.explicit_paths_by_root {
+            let exists = path.exists();
+            self.resolution.add_explicit(path.clone(), exists);
+
+            if !exists {
+                self.emit_error(format!("config file not found: {}", path));
+                continue;
+            }
+
+            let contents = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    self.emit_error(format!("failed to read {}: {}", path, e));
+                    continue;
+                }
+            };
+
+            let parsed = match self.config.registry.parse_file(path, &contents) {
+                Ok(v) => v,
+                Err(e) => {
+                    self.emit_error(format!("failed to parse {}: {}", path, e));
+                    continue;
+                }
+            };
+
+            self.targeted_values.insert(field_name.clone(), parsed);
+        }
     }
 
     /// Resolve which file path to use.
@@ -337,7 +382,13 @@ impl<'a> FileParseContext<'a> {
         // If we have config schemas and a parsed value, use ValueBuilder
         // to validate and collect unused keys
         let output = if !self.schema.configs().is_empty() {
-            if let Some(ref parsed) = self.value {
+            if !self.targeted_values.is_empty() {
+                Self::targeted_config_output(
+                    self.schema,
+                    &self.targeted_values,
+                    self.early_diagnostics,
+                )
+            } else if let Some(ref parsed) = self.value {
                 if self.schema.configs().len() == 1 {
                     let config_schema = &self.schema.configs()[0];
                     // Create a ValueBuilder and import the parsed tree
@@ -367,7 +418,7 @@ impl<'a> FileParseContext<'a> {
                     unused_keys: Vec::new(),
                     diagnostics: self.early_diagnostics,
                     source_text: None,
-                    config_file_path: None,
+                    config_file_paths: IndexMap::default(),
                 }
             }
         } else {
@@ -377,7 +428,7 @@ impl<'a> FileParseContext<'a> {
                 unused_keys: Vec::new(),
                 diagnostics: self.early_diagnostics,
                 source_text: None,
-                config_file_path: None,
+                config_file_paths: IndexMap::default(),
             }
         };
 
@@ -410,7 +461,7 @@ impl<'a> FileParseContext<'a> {
                 unused_keys,
                 diagnostics,
                 source_text: None,
-                config_file_path: None,
+                config_file_paths: IndexMap::default(),
             };
         };
 
@@ -459,7 +510,56 @@ impl<'a> FileParseContext<'a> {
             unused_keys,
             diagnostics,
             source_text: None,
-            config_file_path: None,
+            config_file_paths: IndexMap::default(),
+        }
+    }
+
+    fn targeted_config_output(
+        schema: &Schema,
+        targeted_values: &IndexMap<String, ConfigValue>,
+        early_diagnostics: Vec<Diagnostic>,
+    ) -> LayerOutput {
+        let mut root = IndexMap::default();
+        let mut unused_keys = Vec::new();
+        let mut diagnostics = early_diagnostics;
+
+        for (field_name, config_value) in targeted_values {
+            let Some(config_schema) = schema
+                .configs()
+                .iter()
+                .find(|config_schema| config_schema.field_name() == Some(field_name.as_str()))
+            else {
+                unused_keys.push(crate::driver::UnusedKey {
+                    key: vec![field_name.clone()],
+                    provenance: get_provenance(config_value)
+                        .cloned()
+                        .unwrap_or(Provenance::Default),
+                });
+                continue;
+            };
+
+            let mut builder = ValueBuilder::new(config_schema);
+            builder.import_tree(config_value);
+            let mut builder_output =
+                builder.into_output_with_value(Some(config_value.clone()), None);
+
+            if let Some(value) = builder_output.value {
+                root.insert(field_name.clone(), value);
+            }
+
+            for unused_key in &mut builder_output.unused_keys {
+                unused_key.key.insert(0, field_name.clone());
+            }
+            unused_keys.extend(builder_output.unused_keys);
+            diagnostics.extend(builder_output.diagnostics);
+        }
+
+        LayerOutput {
+            value: Some(ConfigValue::Object(Sourced::new(root))),
+            unused_keys,
+            diagnostics,
+            source_text: None,
+            config_file_paths: IndexMap::default(),
         }
     }
 }

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -152,6 +152,26 @@ pub struct ConfigStructSchema {
 
     /// Fields from the struct
     fields: IndexMap<String, ConfigFieldSchema, RandomState>,
+
+    /// Help-only groups for fields that were flattened from another struct.
+    field_groups: Vec<ConfigFieldGroupSchema>,
+}
+
+/// Help metadata for a flattened config field.
+#[derive(Facet, Debug, Clone)]
+#[facet(skip_all_unless_truthy)]
+pub struct ConfigFieldGroupSchema {
+    /// Field name of the flattened struct in the source type.
+    name: String,
+
+    /// Doc comments from the flattened field.
+    docs: Docs,
+
+    /// Fields contributed by the flattened struct.
+    fields: IndexMap<String, ConfigFieldSchema, RandomState>,
+
+    /// Nested flattened groups contributed by the flattened struct.
+    field_groups: Vec<ConfigFieldGroupSchema>,
 }
 
 #[derive(Facet, Debug, Default, Clone)]
@@ -710,9 +730,36 @@ impl ConfigStructSchema {
         &self.fields
     }
 
+    /// Get help-only flattened field groups for this config struct.
+    pub fn field_groups(&self) -> &[ConfigFieldGroupSchema] {
+        &self.field_groups
+    }
+
     /// Get the shape of this config struct.
     pub fn shape(&self) -> &'static Shape {
         self.shape
+    }
+}
+
+impl ConfigFieldGroupSchema {
+    /// Get the flattened field name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get documentation from the flattened field.
+    pub fn docs(&self) -> &Docs {
+        &self.docs
+    }
+
+    /// Get the fields contributed by the flattened struct.
+    pub fn fields(&self) -> &IndexMap<String, ConfigFieldSchema, RandomState> {
+        &self.fields
+    }
+
+    /// Get nested flattened field groups.
+    pub fn field_groups(&self) -> &[ConfigFieldGroupSchema] {
+        &self.field_groups
     }
 }
 

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -146,6 +146,13 @@ pub struct ConfigStructSchema {
     /// Only present on the top-level config struct, not nested structs.
     env_prefix: Option<String>,
 
+    /// Whether this root config field was also marked `#[facet(flatten)]`.
+    ///
+    /// The config sources still use the root as their namespace, but the merged
+    /// value is flattened before deserialization so Facet sees the shape it
+    /// expects.
+    flattened_root: bool,
+
     /// Shape of the config struct.
     #[facet(skip)]
     shape: &'static Shape,
@@ -296,6 +303,14 @@ pub struct Subcommand {
 pub struct ArgSchema {
     /// Argument name / effective name (rename or field name).
     name: String,
+
+    /// Path where this argument writes in ConfigValue.
+    ///
+    /// Most arguments write to `[name]`. Arguments exposed from a flattened
+    /// config root write to `[config_root, field]` so they merge with env/file
+    /// sources before the root is flattened for deserialization.
+    #[facet(skip)]
+    insertion_path: Vec<String>,
 
     /// Documentation for this argument.
     docs: Docs,
@@ -636,6 +651,11 @@ impl ArgSchema {
         &self.name
     }
 
+    /// Get the ConfigValue insertion path for this argument.
+    pub fn insertion_path(&self) -> &[String] {
+        &self.insertion_path
+    }
+
     /// Get the argument kind (positional or named).
     pub fn kind(&self) -> &ArgKind {
         &self.kind
@@ -723,6 +743,12 @@ impl ConfigStructSchema {
     /// Get the environment variable prefix (e.g., "MYAPP").
     pub fn env_prefix(&self) -> Option<&str> {
         self.env_prefix.as_deref()
+    }
+
+    /// Check whether this root config field should be flattened before
+    /// deserialization.
+    pub fn flattened_root(&self) -> bool {
+        self.flattened_root
     }
 
     /// Get the fields of this config struct.

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -824,6 +824,22 @@ impl ConfigValueSchema {
             ConfigValueSchema::Leaf(leaf) => leaf.shape.type_identifier,
         }
     }
+
+    /// Check if this is an Option type.
+    pub fn is_option(&self) -> bool {
+        matches!(self, ConfigValueSchema::Option { .. })
+    }
+
+    /// Check if this is a boolean type, unwrapping Option if present.
+    pub fn is_bool(&self) -> bool {
+        matches!(
+            self.inner_if_option(),
+            ConfigValueSchema::Leaf(LeafSchema {
+                kind: LeafKind::Scalar(ScalarType::Bool),
+                ..
+            })
+        )
+    }
 }
 
 impl ValueSchema {

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -4,8 +4,9 @@ use crate::{
     Attr,
     schema::{
         ArgKind, ArgLevelSchema, ArgSchema, ConfigEnumSchema, ConfigEnumVariantSchema,
-        ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema, ConfigVecSchema, Docs, LeafKind,
-        LeafSchema, ScalarType, Schema, SpecialFields, Subcommand, ValueSchema,
+        ConfigFieldGroupSchema, ConfigFieldSchema, ConfigStructSchema, ConfigValueSchema,
+        ConfigVecSchema, Docs, LeafKind, LeafSchema, ScalarType, Schema, SpecialFields, Subcommand,
+        ValueSchema,
         error::{SchemaError, SchemaErrorContext},
     },
 };
@@ -466,6 +467,7 @@ fn config_struct_schema_from_shape_inner(
     let apply_env_subst_to_children = parent_env_subst_all || this_env_subst_all;
 
     let mut fields_map: IndexMap<String, ConfigFieldSchema, RandomState> = IndexMap::default();
+    let mut field_groups = Vec::new();
 
     for field in struct_type.fields {
         let field_ctx = ctx.with_field(field.name);
@@ -499,6 +501,13 @@ fn config_struct_schema_from_shape_inner(
                 new_prefix,
                 apply_env_subst_to_children,
             )?;
+
+            field_groups.push(ConfigFieldGroupSchema {
+                name: field.effective_name().to_string(),
+                docs: docs_from_lines(field.doc),
+                fields: inner.fields.clone(),
+                field_groups: inner.field_groups.clone(),
+            });
 
             // Merge the inner fields into our fields (checking for conflicts)
             for (name, field_schema) in inner.fields {
@@ -554,6 +563,7 @@ fn config_struct_schema_from_shape_inner(
         env_prefix,
         shape,
         fields: fields_map,
+        field_groups,
     })
 }
 

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -50,6 +50,7 @@ impl Schema {
                 docs_from_lines(field.doc),
                 Some(field.effective_name().to_string()),
                 env_prefix,
+                field.is_flattened(),
             )?);
         }
         // Extract docs from the top-level shape
@@ -72,6 +73,7 @@ fn has_any_args_attr(field: &Field) -> bool {
         || field.has_attr(Some("args"), "short")
         || field.has_attr(Some("args"), "counted")
         || field.has_attr(Some("args"), "env_prefix")
+        || field.is_flattened()
 }
 
 /// Extract the env_prefix value from a field's `#[facet(args::env_prefix = "...")]` attribute.
@@ -344,7 +346,14 @@ fn value_schema_from_shape(
         }),
         _ => match &shape.ty {
             Type::User(UserType::Struct(_)) => Ok(ValueSchema::Struct {
-                fields: config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None)?,
+                fields: config_struct_schema_from_shape(
+                    shape,
+                    ctx,
+                    Docs::default(),
+                    None,
+                    None,
+                    false,
+                )?,
                 shape,
             }),
             _ => Ok(ValueSchema::Leaf(leaf_schema_from_shape(shape, ctx)?)),
@@ -367,13 +376,49 @@ fn config_value_schema_from_shape(
         })),
         _ => match &shape.ty {
             Type::User(UserType::Struct(_)) => Ok(ConfigValueSchema::Struct(
-                config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None)?,
+                config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None, false)?,
             )),
             Type::User(UserType::Enum(enum_type)) => Ok(ConfigValueSchema::Enum(
                 config_enum_schema_from_shape(shape, *enum_type, ctx)?,
             )),
             _ => Ok(ConfigValueSchema::Leaf(leaf_schema_from_shape(shape, ctx)?)),
         },
+    }
+}
+
+fn value_schema_from_config_value_schema(value: &ConfigValueSchema) -> ValueSchema {
+    match value {
+        ConfigValueSchema::Leaf(leaf) => ValueSchema::Leaf(leaf.clone()),
+        ConfigValueSchema::Option { value, shape } => ValueSchema::Option {
+            value: Box::new(value_schema_from_config_value_schema(value)),
+            shape,
+        },
+        ConfigValueSchema::Vec(vec_schema) => ValueSchema::Vec {
+            element: Box::new(value_schema_from_config_value_schema(vec_schema.element())),
+            shape: vec_schema.shape(),
+        },
+        ConfigValueSchema::Struct(struct_schema) => ValueSchema::Struct {
+            fields: struct_schema.clone(),
+            shape: struct_schema.shape(),
+        },
+        ConfigValueSchema::Enum(enum_schema) => ValueSchema::Leaf(LeafSchema {
+            kind: LeafKind::Enum {
+                variants: enum_schema
+                    .variants()
+                    .keys()
+                    .map(|name| name.to_kebab_case())
+                    .collect(),
+            },
+            shape: enum_schema.shape(),
+        }),
+    }
+}
+
+fn value_schema_is_multiple(value: &ValueSchema) -> bool {
+    match value {
+        ValueSchema::Option { value, .. } => value_schema_is_multiple(value),
+        ValueSchema::Vec { .. } => true,
+        _ => false,
     }
 }
 
@@ -428,27 +473,44 @@ fn config_struct_schema_from_shape(
     docs: Docs,
     field_name: Option<String>,
     env_prefix: Option<String>,
+    flattened_root: bool,
 ) -> Result<ConfigStructSchema, SchemaError> {
     config_struct_schema_from_shape_inner(
         shape,
         ctx,
         docs,
-        field_name,
-        env_prefix,
-        Vec::new(),
-        false,
+        ConfigStructBuildOptions {
+            field_name,
+            env_prefix,
+            flattened_root,
+            path_prefix: Vec::new(),
+            parent_env_subst_all: false,
+        },
     )
+}
+
+struct ConfigStructBuildOptions {
+    field_name: Option<String>,
+    env_prefix: Option<String>,
+    flattened_root: bool,
+    path_prefix: Vec<String>,
+    parent_env_subst_all: bool,
 }
 
 fn config_struct_schema_from_shape_inner(
     shape: &'static Shape,
     ctx: &SchemaErrorContext,
     docs: Docs,
-    field_name: Option<String>,
-    env_prefix: Option<String>,
-    path_prefix: Vec<String>,
-    parent_env_subst_all: bool,
+    options: ConfigStructBuildOptions,
 ) -> Result<ConfigStructSchema, SchemaError> {
+    let ConfigStructBuildOptions {
+        field_name,
+        env_prefix,
+        flattened_root,
+        path_prefix,
+        parent_env_subst_all,
+    } = options;
+
     let struct_type = match &shape.ty {
         Type::User(UserType::Struct(s)) => *s,
         _ => {
@@ -496,10 +558,13 @@ fn config_struct_schema_from_shape_inner(
                 inner_shape,
                 &field_ctx,
                 Docs::default(),
-                None,
-                None,
-                new_prefix,
-                apply_env_subst_to_children,
+                ConfigStructBuildOptions {
+                    field_name: None,
+                    env_prefix: None,
+                    flattened_root: false,
+                    path_prefix: new_prefix,
+                    parent_env_subst_all: apply_env_subst_to_children,
+                },
             )?;
 
             field_groups.push(ConfigFieldGroupSchema {
@@ -561,6 +626,7 @@ fn config_struct_schema_from_shape_inner(
         docs,
         field_name,
         env_prefix,
+        flattened_root,
         shape,
         fields: fields_map,
         field_groups,
@@ -678,11 +744,65 @@ fn arg_level_from_fields_with_prefix(
     let mut first_subcommand_field: Option<SchemaErrorContext> = None;
 
     for field in fields {
+        let field_ctx = ctx.with_field(field.name);
+
         if is_config_field(field) {
+            if field.is_flattened() {
+                let shape = field.shape();
+                let config_shape = match shape.def {
+                    Def::Option(opt) => opt.t,
+                    _ => shape,
+                };
+                let config_field_name = field.effective_name().to_string();
+                let config_schema = config_struct_schema_from_shape(
+                    config_shape,
+                    &field_ctx,
+                    docs_from_lines(field.doc),
+                    Some(config_field_name.clone()),
+                    extract_env_prefix(field),
+                    true,
+                )?;
+
+                for (name, config_field_schema) in config_schema.fields() {
+                    let long = name.to_kebab_case();
+                    if let Some(existing_ctx) = seen_long.get(&long) {
+                        return Err(SchemaError::new(
+                            existing_ctx.clone(),
+                            format!("duplicate flag `--{long}` (from flattened config root)"),
+                        )
+                        .with_primary_label(format!("`--{long}` first defined here"))
+                        .with_label(field_ctx.clone(), "flattened config root defined here"));
+                    }
+                    if args.contains_key(name) {
+                        return Err(SchemaError::new(
+                            field_ctx.clone(),
+                            format!("duplicate argument `{name}` (from flattened config root)"),
+                        )
+                        .with_primary_label("flattened config root defined here"));
+                    }
+                    seen_long.insert(long, field_ctx.clone());
+
+                    let value = value_schema_from_config_value_schema(config_field_schema.value());
+                    let arg = ArgSchema {
+                        name: name.clone(),
+                        insertion_path: vec![config_field_name.clone(), name.clone()],
+                        docs: config_field_schema.docs().clone(),
+                        kind: ArgKind::Named {
+                            short: None,
+                            counted: false,
+                        },
+                        multiple: value_schema_is_multiple(&value),
+                        value,
+                        label: None,
+                        required: false,
+                        default: None,
+                    };
+
+                    args.insert(name.clone(), arg);
+                }
+            }
             continue;
         }
-
-        let field_ctx = ctx.with_field(field.name);
 
         // Handle flattened fields - recurse into the inner struct
         if field.is_flattened() {
@@ -1014,6 +1134,7 @@ fn arg_level_from_fields_with_prefix(
 
         let arg = ArgSchema {
             name: effective_name.clone(),
+            insertion_path: vec![effective_name.clone()],
             docs,
             kind,
             value,
@@ -1022,6 +1143,14 @@ fn arg_level_from_fields_with_prefix(
             multiple,
             default,
         };
+
+        if args.contains_key(&effective_name) {
+            return Err(SchemaError::new(
+                field_ctx.clone(),
+                format!("duplicate argument `{effective_name}`"),
+            )
+            .with_primary_label("defined again here"));
+        }
 
         args.insert(effective_name, arg);
     }

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -222,6 +222,9 @@ fn extract_field_default(field: &Field) -> Option<crate::config_value::ConfigVal
             // Don't return null for types that shouldn't be null - that indicates
             // the serialization couldn't represent the default value properly
             if matches!(config_value, crate::config_value::ConfigValue::Null(_)) {
+                if let Some(value) = from_trait_vec_default(default_source, shape) {
+                    return Some(value);
+                }
                 tracing::debug!(
                     field = field.name,
                     "extract_field_default: serialized to null, skipping"
@@ -237,6 +240,9 @@ fn extract_field_default(field: &Field) -> Option<crate::config_value::ConfigVal
             }
         }
         Err(e) => {
+            if let Some(value) = from_trait_vec_default(default_source, shape) {
+                return Some(value);
+            }
             tracing::debug!(
                 field = field.name,
                 error = %e,
@@ -245,6 +251,25 @@ fn extract_field_default(field: &Field) -> Option<crate::config_value::ConfigVal
             None
         }
     }
+}
+
+fn from_trait_vec_default(
+    default_source: &facet_core::DefaultSource,
+    shape: &'static Shape,
+) -> Option<crate::config_value::ConfigValue> {
+    if !matches!(default_source, facet_core::DefaultSource::FromTrait)
+        || !matches!(shape.def, Def::List(_))
+    {
+        return None;
+    }
+
+    Some(crate::config_value::ConfigValue::Array(
+        crate::config_value::Sourced {
+            value: Vec::new(),
+            span: None,
+            provenance: Some(crate::provenance::Provenance::Default),
+        },
+    ))
 }
 
 fn docs_from_lines(lines: &'static [&'static str]) -> Docs {

--- a/crates/figue/src/value_builder.rs
+++ b/crates/figue/src/value_builder.rs
@@ -310,7 +310,7 @@ impl<'a> ValueBuilder<'a> {
             unused_keys: self.unused_keys,
             diagnostics: self.diagnostics,
             source_text: None,
-            config_file_path: None,
+            config_file_paths: IndexMap::default(),
         }
     }
 
@@ -406,7 +406,7 @@ impl<'a> ValueBuilder<'a> {
             unused_keys: self.unused_keys,
             diagnostics: self.diagnostics,
             source_text: None,
-            config_file_path: None,
+            config_file_paths: IndexMap::default(),
         }
     }
 

--- a/crates/figue/tests/integration/deser_errors.rs
+++ b/crates/figue/tests/integration/deser_errors.rs
@@ -118,8 +118,10 @@ fn test_deser_error_env_number_out_of_range() {
 fn test_deser_error_file_wrong_type_for_port() {
     // Port expects u16 but JSON provides a string
     let config_json = r#"{
-        "port": "not_a_number",
-        "host": "localhost"
+        "config": {
+            "port": "not_a_number",
+            "host": "localhost"
+        }
     }"#;
 
     let config = builder::<ArgsWithSimpleConfig>()
@@ -141,9 +143,11 @@ fn test_deser_error_file_wrong_type_for_port() {
 fn test_deser_error_file_nested_wrong_type() {
     // max_connections expects u32 but JSON provides a string
     let config_json = r#"{
-        "database": {
-            "url": "postgres://localhost/db",
-            "max_connections": "lots"
+        "config": {
+            "database": {
+                "url": "postgres://localhost/db",
+                "max_connections": "lots"
+            }
         }
     }"#;
 
@@ -192,8 +196,10 @@ fn test_deser_error_cli_override_wrong_type() {
 fn test_deser_error_env_overrides_valid_file() {
     // File has valid port, but env overrides with invalid value
     let config_json = r#"{
-        "port": 8080,
-        "host": "localhost"
+        "config": {
+            "port": 8080,
+            "host": "localhost"
+        }
     }"#;
 
     let env = MockEnv::from_pairs([("APP__PORT", "invalid")]);

--- a/crates/figue/tests/integration/env_subst.rs
+++ b/crates/figue/tests/integration/env_subst.rs
@@ -39,7 +39,7 @@ fn test_basic_substitution_var_set() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_dir": "${FIGUE_TEST_BASE_PATH}/data"}"#,
+                r#"{"config": {"data_dir": "${FIGUE_TEST_BASE_PATH}/data"}}"#,
                 "config.json",
             )
         })
@@ -65,7 +65,7 @@ fn test_missing_var_error() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_dir": "${FIGUE_TEST_NOT_SET}/data"}"#,
+                r#"{"config": {"data_dir": "${FIGUE_TEST_NOT_SET}/data"}}"#,
                 "config.json",
             )
         })
@@ -94,7 +94,7 @@ fn test_default_value_used() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_dir": "${FIGUE_TEST_MAYBE_SET:-/default/path}"}"#,
+                r#"{"config": {"data_dir": "${FIGUE_TEST_MAYBE_SET:-/default/path}"}}"#,
                 "config.json",
             )
         })
@@ -117,7 +117,7 @@ fn test_default_value_ignored_when_set() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_dir": "${FIGUE_TEST_ACTUALLY_SET:-/default/path}"}"#,
+                r#"{"config": {"data_dir": "${FIGUE_TEST_ACTUALLY_SET:-/default/path}"}}"#,
                 "config.json",
             )
         })
@@ -138,7 +138,7 @@ fn test_default_value_ignored_when_set() {
 fn test_escape_mechanism() {
     let config = figue::builder::<ArgsWithEnvSubst>()
         .unwrap()
-        .file(|f| f.content(r#"{"data_dir": "$${LITERAL}"}"#, "config.json"))
+        .file(|f| f.content(r#"{"config": {"data_dir": "$${LITERAL}"}}"#, "config.json"))
         .build();
 
     let result = Driver::new(config).run();
@@ -159,7 +159,7 @@ fn test_multiple_substitutions() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_dir": "${FIGUE_TEST_PATH_A}/${FIGUE_TEST_PATH_B}"}"#,
+                r#"{"config": {"data_dir": "${FIGUE_TEST_PATH_A}/${FIGUE_TEST_PATH_B}"}}"#,
                 "config.json",
             )
         })
@@ -198,7 +198,7 @@ fn test_per_field_opt_in() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"with_subst": "${FIGUE_TEST_SUBST_VAR}", "without_subst": "${FIGUE_TEST_SUBST_VAR}"}"#,
+                r#"{"config": {"with_subst": "${FIGUE_TEST_SUBST_VAR}", "without_subst": "${FIGUE_TEST_SUBST_VAR}"}}"#,
                 "config.json",
             )
         })
@@ -239,7 +239,7 @@ fn test_container_opt_in() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"path_a": "${FIGUE_TEST_ALL_BASE}/a", "path_b": "${FIGUE_TEST_ALL_BASE}/b"}"#,
+                r#"{"config": {"path_a": "${FIGUE_TEST_ALL_BASE}/a", "path_b": "${FIGUE_TEST_ALL_BASE}/b"}}"#,
                 "config.json",
             )
         })
@@ -283,7 +283,7 @@ fn test_nested_structs_no_propagate() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"direct_path": "${FIGUE_TEST_NESTED_BASE}/direct", "nested": {"nested_path": "${FIGUE_TEST_NESTED_BASE}/nested"}}"#,
+                r#"{"config": {"direct_path": "${FIGUE_TEST_NESTED_BASE}/direct", "nested": {"nested_path": "${FIGUE_TEST_NESTED_BASE}/nested"}}}"#,
                 "config.json",
             )
         })
@@ -333,7 +333,7 @@ fn test_flatten_inherits_env_subst_all() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"direct_path": "${FIGUE_TEST_FLATTEN_BASE}/direct", "flattened_path": "${FIGUE_TEST_FLATTEN_BASE}/flattened"}"#,
+                r#"{"config": {"direct_path": "${FIGUE_TEST_FLATTEN_BASE}/direct", "flattened_path": "${FIGUE_TEST_FLATTEN_BASE}/flattened"}}"#,
                 "config.json",
             )
         })
@@ -373,7 +373,7 @@ fn test_pathbuf_substitution() {
         .unwrap()
         .file(|f| {
             f.content(
-                r#"{"data_path": "${FIGUE_TEST_PATHBUF_BASE}/files"}"#,
+                r#"{"config": {"data_path": "${FIGUE_TEST_PATHBUF_BASE}/files"}}"#,
                 "config.json",
             )
         })

--- a/crates/figue/tests/integration/layered.rs
+++ b/crates/figue/tests/integration/layered.rs
@@ -262,6 +262,46 @@ fn test_layered_multiple_config_roots() {
     assert!(matches!(args.command, MultiConfigCommand::Run));
 }
 
+#[test]
+fn test_layered_multiple_config_roots_cli_file_targets_matching_root() {
+    use std::io::Write;
+
+    let mut cfg_file = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    write!(
+        cfg_file,
+        r#"{{
+            "host": "file-host",
+            "port": 3000
+        }}"#
+    )
+    .unwrap();
+
+    let cfg_path = cfg_file.path().to_str().unwrap();
+    let config = builder::<MultiConfigArgs>()
+        .unwrap()
+        .cli(|cli| {
+            cli.args([
+                "--cfg",
+                cfg_path,
+                "--cfg.host",
+                "cli-host",
+                "--eval.dataset",
+                "cli-dataset",
+                "run",
+            ])
+        })
+        .build();
+
+    let args = Driver::new(config).run().unwrap();
+
+    assert_eq!(args.cfg.host, "cli-host");
+    assert_eq!(args.cfg.port, 3000);
+    assert_eq!(args.eval.dataset, "cli-dataset");
+    assert_eq!(args.eval.samples, 10);
+    assert!(!args.eval.enabled);
+    assert!(matches!(args.command, MultiConfigCommand::Run));
+}
+
 /// Simpler structure for testing dump output with all sources visible.
 #[derive(Facet, Debug)]
 struct SimpleArgs {

--- a/crates/figue/tests/integration/layered.rs
+++ b/crates/figue/tests/integration/layered.rs
@@ -74,6 +74,9 @@ struct FlattenedRunConfig {
     model: String,
 
     #[facet(default)]
+    tag: Vec<String>,
+
+    #[facet(default)]
     tui: bool,
 }
 
@@ -153,6 +156,10 @@ fn test_flattened_config_root_merges_namespaced_sources_then_deserializes_flat()
     let args = Driver::new(config).run().unwrap();
 
     assert!(args.run.tui, "flattened CLI flag should populate run.tui");
+    assert!(
+        args.run.tag.is_empty(),
+        "explicit Vec default inside flattened config root should be preserved"
+    );
     assert_eq!(
         args.run.model, "cli-model",
         "dotted CLI overrides should keep the config-root namespace and override env/file"

--- a/crates/figue/tests/integration/layered.rs
+++ b/crates/figue/tests/integration/layered.rs
@@ -65,11 +65,13 @@ struct TlsConfig {
 fn test_layered_all_sources() {
     // Config file content (lowest priority after defaults)
     let config_json = r#"{
-        "host": "0.0.0.0",
-        "port": 3000,
-        "database": {
-            "url": "postgres://localhost/mydb",
-            "max_connections": 20
+        "config": {
+            "host": "0.0.0.0",
+            "port": 3000,
+            "database": {
+                "url": "postgres://localhost/mydb",
+                "max_connections": 20
+            }
         }
     }"#;
 
@@ -119,10 +121,12 @@ fn test_layered_all_sources() {
 fn test_layered_missing_required_field() {
     // Config file missing database.url (required field)
     let config_json = r#"{
-        "host": "127.0.0.1",
-        "port": 5000,
-        "database": {
-            "max_connections": 5
+        "config": {
+            "host": "127.0.0.1",
+            "port": 5000,
+            "database": {
+                "max_connections": 5
+            }
         }
     }"#;
 
@@ -144,12 +148,14 @@ fn test_layered_missing_required_field() {
 fn test_layered_cli_overrides_all() {
     // File sets everything
     let config_json = r#"{
-        "host": "file-host",
-        "port": 1111,
-        "database": {
-            "url": "postgres://file/db",
-            "max_connections": 100,
-            "timeout_secs": 999
+        "config": {
+            "host": "file-host",
+            "port": 1111,
+            "database": {
+                "url": "postgres://file/db",
+                "max_connections": 100,
+                "timeout_secs": 999
+            }
         }
     }"#;
 
@@ -406,16 +412,18 @@ fn test_layered_dump_shows_all_sources() {
     // This test shows missing required fields with values from multiple sources
     // Demonstrates: nested structs, enums with data, various sources, deep missing fields
     let config_json = r#"{
-        "host": "0.0.0.0",
-        "port": 3000,
-        "max_retries": 5,
-        "logging": {
-            "level": "debug",
-            "format": "Json"
-        },
-        "storage": {
-            "s3": {
-                "region": "eu-west-1"
+        "settings": {
+            "host": "0.0.0.0",
+            "port": 3000,
+            "max_retries": 5,
+            "logging": {
+                "level": "debug",
+                "format": "Json"
+            },
+            "storage": {
+                "s3": {
+                    "region": "eu-west-1"
+                }
             }
         }
     }"#;

--- a/crates/figue/tests/integration/layered.rs
+++ b/crates/figue/tests/integration/layered.rs
@@ -61,6 +61,22 @@ struct TlsConfig {
     key_path: String,
 }
 
+#[derive(Facet, Debug)]
+struct ArgsWithFlattenedConfigRoot {
+    /// Run configuration; config sources keep this root namespace.
+    #[facet(args::config, args::env_prefix = "BEE_RUN")]
+    #[facet(flatten)]
+    run: FlattenedRunConfig,
+}
+
+#[derive(Facet, Debug)]
+struct FlattenedRunConfig {
+    model: String,
+
+    #[facet(default)]
+    tui: bool,
+}
+
 #[test]
 fn test_layered_all_sources() {
     // Config file content (lowest priority after defaults)
@@ -115,6 +131,32 @@ fn test_layered_all_sources() {
     );
     // Default: tls is None
     assert!(args.config.tls.is_none(), "tls should be None (default)");
+}
+
+#[test]
+fn test_flattened_config_root_merges_namespaced_sources_then_deserializes_flat() {
+    let config_json = r#"{
+        "run": {
+            "model": "file-model"
+        }
+    }"#;
+
+    let env = MockEnv::from_pairs([("BEE_RUN__MODEL", "env-model")]);
+
+    let config = builder::<ArgsWithFlattenedConfigRoot>()
+        .unwrap()
+        .cli(|cli| cli.args(["--tui", "--run.model", "cli-model"]))
+        .env(|e| e.source(env))
+        .file(|f| f.content(config_json, "config.json"))
+        .build();
+
+    let args = Driver::new(config).run().unwrap();
+
+    assert!(args.run.tui, "flattened CLI flag should populate run.tui");
+    assert_eq!(
+        args.run.model, "cli-model",
+        "dotted CLI overrides should keep the config-root namespace and override env/file"
+    );
 }
 
 #[test]

--- a/crates/figue/tests/integration/schema_defaults.rs
+++ b/crates/figue/tests/integration/schema_defaults.rs
@@ -36,7 +36,9 @@ struct TestConfig {
 fn test_schema_default_vs_missing() {
     // Only set one field, leave the other two unset
     let config_json = r#"{
-        "field_set": "hello"
+        "config": {
+            "field_set": "hello"
+        }
     }"#;
 
     let config = builder::<Args>()
@@ -86,7 +88,7 @@ struct MultiDefaultConfig {
 #[test]
 fn test_schema_multiple_default_types() {
     // Empty config - only required_string should be missing
-    let config_json = r#"{}"#;
+    let config_json = r#"{"config": {}}"#;
 
     let config = builder::<ArgsMultipleDefaults>()
         .unwrap()

--- a/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_env_overrides_valid_file.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_env_overrides_valid_file.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/figue/tests/integration/deser_errors.rs
-expression: "$crate :: common :: strip_ansi(& report.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& report.to_string())"
 ---
 Error: failed to parse "invalid" as u16 at config.port
-   ╭─[ config.json:3:17 ]
+   ╭─[ config.json:4:21 ]
    │
- 3 │         "host": "localhost"
-   │                 ─────┬─────  
-   │                      ╰─────── failed to parse "invalid" as u16 at config.port
+ 4 │             "host": "localhost"
+   │                     ─────┬─────  
+   │                          ╰─────── failed to parse "invalid" as u16 at config.port
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_file_nested_wrong_type.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_file_nested_wrong_type.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/figue/tests/integration/deser_errors.rs
-expression: "$crate :: common :: strip_ansi(& report.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& report.to_string())"
 ---
 Error: failed to parse "lots" as u32 at config.database.max_connections
-   ╭─[ config.json:3:20 ]
+   ╭─[ config.json:4:24 ]
    │
- 3 │             "url": "postgres://localhost/db",
-   │                    ────────────┬────────────  
-   │                                ╰────────────── failed to parse "lots" as u32 at config.database.max_connections
+ 4 │                 "url": "postgres://localhost/db",
+   │                        ────────────┬────────────  
+   │                                    ╰────────────── failed to parse "lots" as u32 at config.database.max_connections
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_file_wrong_type_for_port.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__deser_errors__deser_error_file_wrong_type_for_port.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/figue/tests/integration/deser_errors.rs
-expression: "$crate :: common :: strip_ansi(& report.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& report.to_string())"
 ---
 Error: failed to parse "not_a_number" as u16 at config.port
-   ╭─[ config.json:4:5 ]
+   ╭─[ config.json:5:9 ]
    │
- 4 │     }
-   │     ┬  
-   │     ╰── failed to parse "not_a_number" as u16 at config.port
+ 5 │         }
+   │         ┬  
+   │         ╰── failed to parse "not_a_number" as u16 at config.port
 ───╯

--- a/crates/figue/tests/integration/snapshots/main__integration__layered__layered_dump_shows_all_sources.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__layered__layered_dump_shows_all_sources.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/figue/tests/integration/layered.rs
-expression: "$crate :: common :: strip_ansi(& err.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& err.to_string())"
 ---
 Error: Missing required fields:
 
@@ -13,19 +13,19 @@ Sources:
 
 debug......... true..... --debug
 name.......... ......... ⨯ MISSING
-host.......... 0.0.0.0.. app.json:2
+host.......... 0.0.0.0.. app.json:3
 port.......... 4000..... $MYAPP__PORT
-max_retries... 5........ app.json:4
+max_retries... 5........ app.json:5
 timeout_ms.... 10000.... $MYAPP__TIMEOUT_MS
 experimental.. true..... --settings.experimental
 logging
-├─ level... debug......... app.json:6
-├─ format.. Json.......... app.json:7
+├─ level... debug......... app.json:7
+├─ format.. Json.......... app.json:8
 └─ file.... /var/log/app.. $MYAPP__LOGGING__FILE
 storage
 └─ s3
 ···├─ bucket.... ........... ⨯ MISSING
-···├─ region.... eu-west-1.. app.json:11
+···├─ region.... eu-west-1.. app.json:12
 ···└─ endpoint.. <default>.. DEFAULT
 
 Missing:

--- a/crates/figue/tests/integration/snapshots/main__integration__layered__layered_missing_required_field.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__layered__layered_missing_required_field.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/figue/tests/integration/layered.rs
-expression: "$crate :: common :: strip_ansi(& err.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& err.to_string())"
 ---
 Error: Missing required fields:
 
@@ -12,11 +12,11 @@ Sources:
 └─ defaults
 
 verbose.. true....... -v
-host..... 127.0.0.1.. config.json:2
-port..... 5000....... config.json:3
+host..... 127.0.0.1.. config.json:3
+port..... 5000....... config.json:4
 database
 ├─ url.............. .... ⨯ MISSING
-├─ max_connections.. 5... config.json:5
+├─ max_connections.. 5... config.json:6
 └─ timeout_secs..... 15.. $APP__DATABASE__TIMEOUT_SECS
 tls...... <default>.. DEFAULT
 

--- a/crates/figue/tests/integration/snapshots/main__integration__schema_defaults__schema_default_vs_missing.snap
+++ b/crates/figue/tests/integration/snapshots/main__integration__schema_defaults__schema_default_vs_missing.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/figue/tests/integration/schema_defaults.rs
-expression: "$crate :: common :: strip_ansi(& err.to_string())"
+expression: "strip_ansi_escapes :: strip_str(& err.to_string())"
 ---
 Error: Missing required fields:
 
@@ -11,7 +11,7 @@ Sources:
 ├─ cli --config.*
 └─ defaults
 
-field_set........... hello.. config.json:2
+field_set........... hello.. config.json:3
 field_with_default.. 42..... DEFAULT
 field_required...... ....... ⨯ MISSING
 

--- a/crates/figue/tests/integration/unknown_keys.rs
+++ b/crates/figue/tests/integration/unknown_keys.rs
@@ -121,8 +121,10 @@ fn test_help_short_flag_works_with_unknown_env_keys_strict() {
 fn test_help_works_with_unknown_file_keys_strict() {
     // Config file has unknown keys AND user passes --help
     let config_json = r#"{
-        "auth": {
-            "email_from": "noreply@example.com"
+        "config": {
+            "auth": {
+                "email_from": "noreply@example.com"
+            }
         }
     }"#;
 
@@ -196,9 +198,11 @@ fn test_unknown_key_in_env_strict_mode_shows_valid_fields() {
 fn test_unknown_key_in_file_strict_mode_shows_valid_fields() {
     // Config file has unknown keys
     let config_json = r#"{
-        "auth": {
-            "email_from": "noreply@example.com",
-            "rp_id": "example.com"
+        "config": {
+            "auth": {
+                "email_from": "noreply@example.com",
+                "rp_id": "example.com"
+            }
         }
     }"#;
 


### PR DESCRIPTION
## Summary
This PR tightens Figue's config layering around multiple config roots, CLI-provided config files, boolean config overrides, and flattened config roots. It also includes the HTML help feedback pass so generated help remains navigable and readable for large schemas.

## Changes
- Target CLI-provided config files to the matching config root, and require root blocks for global config files when a command has multiple config roots.
- Allow bare boolean config overrides, including `--flag`, `--flag=false`, and `--no-flag` forms where applicable.
- Support `#[facet(args::config)] #[facet(flatten)]` roots so ergonomic CLI flags can still merge with env/file/dotted overrides under the config-root namespace, with collision checks.
- Preserve explicit defaults during schema/default extraction, including `#[facet(default)] Vec<_>` fields inside flattened config roots.
- Improve HTML help layout: scrollable side nav, wrapping long config names/descriptions, compact override rows without redundant value placeholders, and cleaner false/default display.
- Add sticky HTML help breadcrumbs that track the current section/config node and let users jump back to any ancestor.
- Treat flattened config fields as help-only collapsible groups using the flattened field docs, without changing actual override paths.

## Testing
- `cargo nextest run -p figue -E 'test(html_help)'`
- `cargo nextest run -p figue -E 'test(flattened_config_root)'`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run -p figue`
- Browser smoke check against generated kitchen-sink HTML at 1141x1285 for breadcrumbs, sticky topbar, scrolling nav, wrapping, and horizontal overflow
- Pre-push checks passed
