### PR TITLE
Validate CLI config overrides

### DIFF
--- a/crates/figue/src/layers/cli.rs
+++ b/crates/figue/src/layers/cli.rs
@@ -191,6 +191,8 @@ struct ParentFlagLookup {
 struct ConfigOverrideTarget<'a> {
     /// Flag name without the leading `--` and without a leading `no-`.
     flag_name: &'a str,
+    /// Schema for the config object being overridden.
+    config_schema: &'a crate::schema::ConfigStructSchema,
     /// Kebab-case config root name used on the CLI.
     cli_root: String,
     /// Effective config field name in the schema.
@@ -361,6 +363,7 @@ impl<'a> ParseContext<'a> {
                     let is_bool = Self::config_path_is_bool(config_schema, &parts);
                     let target = ConfigOverrideTarget {
                         flag_name: override_flag_name,
+                        config_schema,
                         cli_root: cli_root.to_string(),
                         config_field_name: config_field_name.to_string(),
                         negated,
@@ -881,10 +884,7 @@ impl<'a> ParseContext<'a> {
 
             let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
             let provenance = Provenance::cli(arg, "false");
-            self.config_builders
-                .get_mut(&target.config_field_name)
-                .expect("config_builder must exist when parsing config overrides")
-                .set(&path, LeafValue::Bool(false), None, provenance);
+            self.set_config_override(&target, &path, LeafValue::Bool(false), None, provenance);
             self.index += 1;
             return;
         }
@@ -917,10 +917,13 @@ impl<'a> ParseContext<'a> {
             let provenance = Provenance::cli(&prov_arg, provenance_value);
             let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
 
-            self.config_builders
-                .get_mut(&target.config_field_name)
-                .expect("config_builder must exist when parsing config overrides")
-                .set(&path, LeafValue::Bool(value), value_span, provenance);
+            self.set_config_override(
+                &target,
+                &path,
+                LeafValue::Bool(value),
+                value_span,
+                provenance,
+            );
             return;
         }
 
@@ -951,10 +954,30 @@ impl<'a> ParseContext<'a> {
         let path: Vec<String> = parts.iter().map(|s| (*s).to_string()).collect();
         let leaf_value = LeafValue::String(value_str.to_string());
 
-        self.config_builders
+        self.set_config_override(&target, &path, leaf_value, Some(value_span), provenance);
+    }
+
+    fn set_config_override(
+        &mut self,
+        target: &ConfigOverrideTarget<'_>,
+        path: &Vec<String>,
+        value: LeafValue,
+        span: Option<facet_reflect::Span>,
+        provenance: Provenance,
+    ) {
+        let inserted = self
+            .config_builders
             .get_mut(&target.config_field_name)
             .expect("config_builder must exist when parsing config overrides")
-            .set(&path, leaf_value, Some(value_span), provenance);
+            .set(path, value, span, provenance);
+
+        if !inserted {
+            let suggestion = crate::suggest::suggest_config_path(target.config_schema, path);
+            self.emit_error(format!(
+                "unknown flag: --{}{}",
+                target.flag_name, suggestion
+            ));
+        }
     }
 
     fn parse_bool_literal(value: &str) -> Option<bool> {

--- a/crates/figue/src/value_builder.rs
+++ b/crates/figue/src/value_builder.rs
@@ -14,6 +14,7 @@
 use std::hash::RandomState;
 
 use facet_reflect::Span;
+use heck::ToKebabCase;
 use indexmap::IndexMap;
 
 use crate::config_value::{ConfigValue, ObjectMap, Sourced};
@@ -445,7 +446,7 @@ impl<'a> ValueBuilder<'a> {
         let (effective_name, field_schema) = struct_schema
             .fields()
             .iter()
-            .find(|(k, _)| k.to_lowercase() == segment.to_lowercase())?;
+            .find(|(k, _)| Self::schema_key_matches_segment(k, segment))?;
 
         result.insertion_path.push(effective_name.clone());
 
@@ -517,7 +518,7 @@ impl<'a> ValueBuilder<'a> {
         let (variant_name, variant_schema) = enum_schema
             .variants()
             .iter()
-            .find(|(k, _)| k.to_lowercase() == variant_segment.to_lowercase())?;
+            .find(|(k, _)| Self::schema_key_matches_segment(k, variant_segment))?;
 
         // Record enum selection for conflict detection
         result.enum_selections.push(EnumSelection {
@@ -552,7 +553,7 @@ impl<'a> ValueBuilder<'a> {
         let (field_name, field_schema) = variant_schema
             .fields()
             .iter()
-            .find(|(k, _)| k.to_lowercase() == field_segment.to_lowercase())?;
+            .find(|(k, _)| Self::schema_key_matches_segment(k, field_segment))?;
 
         result.insertion_path.push(field_name.clone());
 
@@ -562,6 +563,10 @@ impl<'a> ValueBuilder<'a> {
 
         // Continue navigating
         self.resolve_value_path(field_schema.value(), &path[1..], result)
+    }
+
+    fn schema_key_matches_segment(key: &str, segment: &str) -> bool {
+        key.eq_ignore_ascii_case(segment) || key.to_kebab_case().eq_ignore_ascii_case(segment)
     }
 
     /// Check and record enum variant selection. Returns false if there's a conflict.

--- a/crates/figue/tests/integration/unknown_keys.rs
+++ b/crates/figue/tests/integration/unknown_keys.rs
@@ -267,6 +267,26 @@ struct ArgsWithRenamedConfigField {
     builtins: FigueBuiltins,
 }
 
+/// Args with a config root flattened into the top-level CLI namespace.
+#[derive(Facet, Debug)]
+struct ArgsWithFlattenedConfigRoot {
+    #[facet(args::config, args::env_prefix = "APP_RUN")]
+    #[facet(flatten)]
+    run: RunConfig,
+
+    #[facet(flatten)]
+    builtins: FigueBuiltins,
+}
+
+#[derive(Facet, Debug)]
+struct RunConfig {
+    #[facet(default = "default-model")]
+    model: String,
+
+    #[facet(default)]
+    tui: bool,
+}
+
 #[test]
 fn test_config_path_flag_not_silently_ignored() {
     // User passes --config /path/to/file.json
@@ -366,4 +386,70 @@ fn test_renamed_config_path_flag_not_silently_ignored() {
             );
         }
     }
+}
+
+#[test]
+fn test_unknown_cli_config_override_errors_without_strict_mode() {
+    let config = builder::<ArgsWithRenamedConfigField>()
+        .unwrap()
+        .cli(|cli| cli.args(["--cfg.does-not-exist", "yolo"]))
+        .build();
+
+    let err = Driver::new(config).run().unwrap_err();
+    let err_str = err.to_string();
+
+    assert!(
+        err_str.contains("unknown flag: --cfg.does-not-exist"),
+        "unknown config override should be a CLI parse error, got: {}",
+        err_str
+    );
+}
+
+#[test]
+fn test_kebab_case_cli_config_override_is_accepted() {
+    let config = builder::<ArgsWithRenamedConfigField>()
+        .unwrap()
+        .cli(|cli| cli.args(["--cfg.magic-link", "https://example.com/login"]))
+        .build();
+
+    let args = Driver::new(config).run().unwrap();
+
+    assert_eq!(
+        args.config.magic_link.as_deref(),
+        Some("https://example.com/login")
+    );
+}
+
+#[test]
+fn test_unknown_flattened_config_root_flag_errors_without_strict_mode() {
+    let config = builder::<ArgsWithFlattenedConfigRoot>()
+        .unwrap()
+        .cli(|cli| cli.args(["--does-not-exist", "yolo"]))
+        .build();
+
+    let err = Driver::new(config).run().unwrap_err();
+    let err_str = err.to_string();
+
+    assert!(
+        err_str.contains("unknown flag: --does-not-exist"),
+        "unknown flattened config root flag should be a CLI parse error, got: {}",
+        err_str
+    );
+}
+
+#[test]
+fn test_unknown_namespaced_flattened_config_root_override_errors_without_strict_mode() {
+    let config = builder::<ArgsWithFlattenedConfigRoot>()
+        .unwrap()
+        .cli(|cli| cli.args(["--run.does-not-exist", "yolo"]))
+        .build();
+
+    let err = Driver::new(config).run().unwrap_err();
+    let err_str = err.to_string();
+
+    assert!(
+        err_str.contains("unknown flag: --run.does-not-exist"),
+        "unknown namespaced flattened config root override should be a CLI parse error, got: {}",
+        err_str
+    );
 }


### PR DESCRIPTION
## Summary
- report unknown CLI config overrides immediately instead of silently ignoring them
- accept kebab-case CLI config path segments for schema fields and enum variants
- add coverage for renamed and flattened config root override handling

## Tests
- cargo test -p figue unknown_keys