### PR TITLE
Respect optional config roots

### DIFF
--- a/crates/figue/src/config_value_parser.rs
+++ b/crates/figue/src/config_value_parser.rs
@@ -103,8 +103,9 @@ pub(crate) fn fill_defaults_from_schema(value: &ConfigValue, schema: &Schema) ->
         if let Some(config_value) = new_map.get(&config_field_name) {
             let filled = fill_defaults_from_config_struct(config_value, config_schema, "");
             new_map.insert(config_field_name, filled);
-        } else {
-            // Config field missing - create it with defaults
+        } else if !config_schema.optional_root() {
+            // Required config field missing - create it with defaults.
+            // Optional config roots should stay absent so they deserialize as None.
             let filled = fill_defaults_from_config_struct(
                 &ConfigValue::Object(Sourced::new(IndexMap::default())),
                 config_schema,

--- a/crates/figue/src/driver.rs
+++ b/crates/figue/src/driver.rs
@@ -1737,6 +1737,26 @@ mod tests {
         host: String,
     }
 
+    #[derive(Facet, Debug)]
+    struct OptionalConfigArgs {
+        #[facet(figue::config)]
+        config: Option<RequiredTestConfig>,
+    }
+
+    #[derive(Facet, Debug)]
+    struct RequiredConfigArgs {
+        #[facet(figue::config)]
+        config: RequiredTestConfig,
+    }
+
+    #[derive(Facet, Debug)]
+    struct RequiredTestConfig {
+        database_url: String,
+
+        #[facet(default = 8080)]
+        port: u16,
+    }
+
     #[test]
     fn test_driver_help_flag() {
         let config = builder::<ArgsWithBuiltins>()
@@ -1958,6 +1978,88 @@ mod tests {
                 assert!(output.value.builtins.completions.is_none());
             }
             Err(e) => panic!("expected success, got error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_optional_config_absent_deserializes_to_none() {
+        let config = builder::<OptionalConfigArgs>()
+            .unwrap()
+            .cli(|cli| cli.args(Vec::<String>::new()))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Ok(output) => assert!(output.value.config.is_none()),
+            Err(e) => panic!(
+                "expected optional config absence to succeed, got error: {:?}",
+                e
+            ),
+        }
+    }
+
+    #[test]
+    fn test_required_config_absent_still_errors() {
+        let config = builder::<RequiredConfigArgs>()
+            .unwrap()
+            .cli(|cli| cli.args(Vec::<String>::new()))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Err(DriverError::Failed { report }) => {
+                let rendered = report.render_pretty();
+                assert!(
+                    rendered.contains("Missing required fields") || rendered.contains("Missing:"),
+                    "expected missing-field error, got: {rendered}"
+                );
+            }
+            other => panic!("expected missing required config error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_optional_config_present_complete_deserializes_to_some() {
+        let config = builder::<OptionalConfigArgs>()
+            .unwrap()
+            .cli(|cli| cli.args(["--config.database-url", "postgres://localhost/app"]))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Ok(output) => {
+                let config = output.value.config.expect("config should be present");
+                assert_eq!(config.database_url, "postgres://localhost/app");
+                assert_eq!(config.port, 8080);
+            }
+            Err(e) => panic!(
+                "expected complete optional config to succeed, got error: {:?}",
+                e
+            ),
+        }
+    }
+
+    #[test]
+    fn test_optional_config_present_partial_still_errors() {
+        let config = builder::<OptionalConfigArgs>()
+            .unwrap()
+            .cli(|cli| cli.args(["--config.port", "9000"]))
+            .build();
+
+        let result = Driver::new(config).run().into_result();
+
+        match result {
+            Err(DriverError::Failed { report }) => {
+                let rendered = report.render_pretty();
+                assert!(
+                    rendered.contains("database_url") || rendered.contains("database-url"),
+                    "expected database_url missing-field error, got: {rendered}"
+                );
+            }
+            other => panic!("expected partial optional config to fail, got {:?}", other),
         }
     }
 

--- a/crates/figue/src/missing.rs
+++ b/crates/figue/src/missing.rs
@@ -191,8 +191,9 @@ pub fn collect_missing_fields(
                     env_prefix,
                     missing,
                 );
-            } else {
-                // The entire config struct is missing - report it
+            } else if !config_schema.optional_root() {
+                // The entire required config struct is missing - report it.
+                // Optional config roots are allowed to be absent and deserialize as None.
                 missing.push(MissingFieldInfo {
                     field_name: field_name.to_string(),
                     field_path: field_name.to_string(),

--- a/crates/figue/src/schema.rs
+++ b/crates/figue/src/schema.rs
@@ -146,6 +146,13 @@ pub struct ConfigStructSchema {
     /// Only present on the top-level config struct, not nested structs.
     env_prefix: Option<String>,
 
+    /// Whether this root config field was originally `Option<T>`.
+    ///
+    /// The schema unwraps the inner `T` so config sources can still address its
+    /// fields, but an absent optional root should remain absent instead of being
+    /// synthesized from defaults or reported as missing.
+    optional_root: bool,
+
     /// Whether this root config field was also marked `#[facet(flatten)]`.
     ///
     /// The config sources still use the root as their namespace, but the merged
@@ -743,6 +750,11 @@ impl ConfigStructSchema {
     /// Get the environment variable prefix (e.g., "MYAPP").
     pub fn env_prefix(&self) -> Option<&str> {
         self.env_prefix.as_deref()
+    }
+
+    /// Check whether this root config field was originally `Option<T>`.
+    pub fn optional_root(&self) -> bool {
+        self.optional_root
     }
 
     /// Check whether this root config field should be flattened before

--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -38,6 +38,7 @@ impl Schema {
         let mut configs = Vec::new();
         for (field, field_ctx) in config_fields {
             let shape = field.shape();
+            let optional_root = matches!(shape.def, Def::Option(_));
             let config_shape = match shape.def {
                 Def::Option(opt) => opt.t,
                 _ => shape,
@@ -50,6 +51,7 @@ impl Schema {
                 docs_from_lines(field.doc),
                 Some(field.effective_name().to_string()),
                 env_prefix,
+                optional_root,
                 field.is_flattened(),
             )?);
         }
@@ -378,6 +380,7 @@ fn value_schema_from_shape(
                     None,
                     None,
                     false,
+                    false,
                 )?,
                 shape,
             }),
@@ -400,9 +403,17 @@ fn config_value_schema_from_shape(
             shape,
         })),
         _ => match &shape.ty {
-            Type::User(UserType::Struct(_)) => Ok(ConfigValueSchema::Struct(
-                config_struct_schema_from_shape(shape, ctx, Docs::default(), None, None, false)?,
-            )),
+            Type::User(UserType::Struct(_)) => {
+                Ok(ConfigValueSchema::Struct(config_struct_schema_from_shape(
+                    shape,
+                    ctx,
+                    Docs::default(),
+                    None,
+                    None,
+                    false,
+                    false,
+                )?))
+            }
             Type::User(UserType::Enum(enum_type)) => Ok(ConfigValueSchema::Enum(
                 config_enum_schema_from_shape(shape, *enum_type, ctx)?,
             )),
@@ -498,6 +509,7 @@ fn config_struct_schema_from_shape(
     docs: Docs,
     field_name: Option<String>,
     env_prefix: Option<String>,
+    optional_root: bool,
     flattened_root: bool,
 ) -> Result<ConfigStructSchema, SchemaError> {
     config_struct_schema_from_shape_inner(
@@ -507,6 +519,7 @@ fn config_struct_schema_from_shape(
         ConfigStructBuildOptions {
             field_name,
             env_prefix,
+            optional_root,
             flattened_root,
             path_prefix: Vec::new(),
             parent_env_subst_all: false,
@@ -517,6 +530,7 @@ fn config_struct_schema_from_shape(
 struct ConfigStructBuildOptions {
     field_name: Option<String>,
     env_prefix: Option<String>,
+    optional_root: bool,
     flattened_root: bool,
     path_prefix: Vec<String>,
     parent_env_subst_all: bool,
@@ -531,6 +545,7 @@ fn config_struct_schema_from_shape_inner(
     let ConfigStructBuildOptions {
         field_name,
         env_prefix,
+        optional_root,
         flattened_root,
         path_prefix,
         parent_env_subst_all,
@@ -586,6 +601,7 @@ fn config_struct_schema_from_shape_inner(
                 ConfigStructBuildOptions {
                     field_name: None,
                     env_prefix: None,
+                    optional_root: false,
                     flattened_root: false,
                     path_prefix: new_prefix,
                     parent_env_subst_all: apply_env_subst_to_children,
@@ -651,6 +667,7 @@ fn config_struct_schema_from_shape_inner(
         docs,
         field_name,
         env_prefix,
+        optional_root,
         flattened_root,
         shape,
         fields: fields_map,
@@ -774,6 +791,7 @@ fn arg_level_from_fields_with_prefix(
         if is_config_field(field) {
             if field.is_flattened() {
                 let shape = field.shape();
+                let optional_root = matches!(shape.def, Def::Option(_));
                 let config_shape = match shape.def {
                     Def::Option(opt) => opt.t,
                     _ => shape,
@@ -785,6 +803,7 @@ fn arg_level_from_fields_with_prefix(
                     docs_from_lines(field.doc),
                     Some(config_field_name.clone()),
                     extract_env_prefix(field),
+                    optional_root,
                     true,
                 )?;
 

--- a/crates/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_basic.snap
+++ b/crates/figue/src/schema/snapshots/figue__schema__tests__snapshot_schema_basic.snap
@@ -136,6 +136,7 @@ expression: "facet_json :: to_string_pretty(& value).unwrap()"
       },
       "field_name": "config",
       "env_prefix": "APP",
+      "optional_root": true,
       "fields": {
         "host": {
           "docs": {},


### PR DESCRIPTION
## Summary
- track when an args::config root was originally declared as Option<T>
- leave absent optional config roots absent so they deserialize as None
- continue validating/defaulting optional config roots when they are present
- add regression coverage for absent, complete, and partial optional configs

## Validation
- cargo check -p figue
- cargo test -p figue --lib --quiet
- cargo test -p figue --quiet