### PR TITLE
Support facet skip attribute in configs

### DIFF
--- a/crates/figue/src/schema/from_schema.rs
+++ b/crates/figue/src/schema/from_schema.rs
@@ -573,6 +573,18 @@ fn config_struct_schema_from_shape_inner(
 
     for field in struct_type.fields {
         let field_ctx = ctx.with_field(field.name);
+        if field.flags.contains(facet_core::FieldFlags::SKIP) {
+            if field.default.is_none() {
+                return Err(SchemaError::new(
+                    field_ctx,
+                    format!(
+                        "config field `{}` is skipped but has no default value",
+                        field.name
+                    ),
+                ));
+            }
+            continue;
+        }
 
         // Handle flattened fields - recurse into the inner struct and merge fields
         if field.is_flattened() {

--- a/crates/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
+++ b/crates/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_errors_when_not_defaulted.snap
@@ -1,0 +1,17 @@
+---
+source: crates/figue/src/schema/tests.rs
+expression: stripped
+---
+Error: config field `skipped` is skipped but has no default value
+   ╭─[ <unknown>:2:8 ]
+   │
+ 2 │ struct ArgsWithSkippedNonDefaultConfigField {
+   │        ──────────────────┬─────────────────  
+   │                          ╰─────────────────── defined at crates/figue/src/schema/tests.rs:435
+   │                          │                   
+   │                          ╰─────────────────── config field `skipped` is skipped but has no default value
+   │ 
+ 5 │ }
+   │ ┬  
+   │ ╰── end of definition
+───╯

--- a/crates/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_is_omitted.snap
+++ b/crates/figue/src/schema/snapshots/figue__schema__tests__config_skipped_field_is_omitted.snap
@@ -1,0 +1,30 @@
+---
+source: crates/figue/src/schema/tests.rs
+expression: "facet_json :: to_string_pretty(& value).unwrap()"
+---
+{
+  "docs": {},
+  "args": {
+    "args": {},
+    "subcommands": {}
+  },
+  "configs": [
+    {
+      "docs": {},
+      "field_name": "config",
+      "fields": {
+        "visible": {
+          "docs": {},
+          "value": {
+            "Leaf": {
+              "kind": {
+                "Scalar": "String"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "special": {}
+}

--- a/crates/figue/src/schema/tests.rs
+++ b/crates/figue/src/schema/tests.rs
@@ -406,6 +406,42 @@ fn test_config_flatten_schema_builds() {
     );
 }
 
+#[test]
+fn test_config_skipped_field_is_omitted() {
+    #[derive(Facet)]
+    struct ConfigWithSkippedField {
+        visible: String,
+        #[facet(skip, default)]
+        skipped: String,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithSkippedConfigField {
+        #[facet(args::config)]
+        config: ConfigWithSkippedField,
+    }
+    assert_schema_snapshot!(Schema::from_shape(ArgsWithSkippedConfigField::SHAPE))
+}
+
+#[test]
+fn test_config_skipped_field_errors_when_not_defaulted() {
+    #[derive(Facet)]
+    struct ConfigWithSkippedNonDefaultField {
+        visible: String,
+        #[facet(skip)]
+        skipped: String,
+    }
+
+    #[derive(Facet)]
+    struct ArgsWithSkippedNonDefaultConfigField {
+        #[facet(args::config)]
+        config: ConfigWithSkippedNonDefaultField,
+    }
+    assert_schema_snapshot!(Schema::from_shape(
+        ArgsWithSkippedNonDefaultConfigField::SHAPE
+    ))
+}
+
 /// Deeply nested config flatten: common inside extended
 #[derive(Facet)]
 struct ExtendedConfig {


### PR DESCRIPTION
This allows hiding some config fields that might be derived automatically after parsing.
I made it error on non defaulted skipped fields bc the error was confusing otherwise. See the outdated section for more infos.

<details>
<summary>Outdated</summary>

One downside of this is that without an additional `facet(default)` config deserialization to the concrete T will fail with a rather confusing error message of:
```
missing field `bla` in type `Config`
```
I guess we could catch this where we skip the field and reject it with a nice error?
</details>